### PR TITLE
Reader and writer implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,16 +21,6 @@ jobs:
       with:
         package-name: rosbag2_storage_mcap
         target-ros2-distro: rolling
-        colcon-defaults: |
-          {
-            "build": {
-              "cmake-args": [
-                "-DCMAKE_BUILD_TYPE=Release"
-              ]
-            },
-            "test": {
-            }
-          }
     - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+install/
+log/
+
+.vscode/

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -1,14 +1,28 @@
 cmake_minimum_required(VERSION 3.14)
 project(rosbag2_storage_mcap)
 
+# Set Release build if no build type was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+      "Build type for the build. Possible values are: Debug, Release, RelWithDebInfo, MinSizeRel"
+      FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+      "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
+endif()
+
+# Enable additional warnings and warnings as errors
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Get the ROS_DISTRO environment variable
+set(ROS_DISTRO $ENV{ROS_DISTRO})
+
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(rosbag2_storage REQUIRED)
 find_package(rcutils REQUIRED)
+find_package(ros_environment REQUIRED)
+find_package(rosbag2_storage REQUIRED)
 
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
   message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
@@ -57,6 +71,8 @@ target_link_libraries(${PROJECT_NAME}
   ${CONAN_LIBS}
 )
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=${ROS_DISTRO})
+
 install(
   DIRECTORY
     ${MCAP_INCLUDE_DIRS}/mcap
@@ -71,6 +87,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "ROSBAG2_STORAGE_MCAP_BUILDIN
 ament_target_dependencies(${PROJECT_NAME}
   pluginlib
   rcutils
+  ros_environment
   rosbag2_storage
 )
 

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -11,8 +11,9 @@
   <buildtool_depend>python3-conan-pip</buildtool_depend>
 
   <depend>pluginlib</depend>
-  <depend>rosbag2_storage</depend>
   <depend>rcutils</depend>
+  <depend>ros_environment</depend>
+  <depend>rosbag2_storage</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -137,7 +137,7 @@ void MCAPStorage::open(
         input_ = std::make_unique<std::ifstream>(relative_path_, std::ios::binary);
         data_source_ = std::make_unique<mcap::FileStreamReader>(*input_);
         mcap_reader_ = std::make_unique<mcap::McapReader>();
-        mcap::McapReaderOptions options;
+        mcap::McapReaderOptions options{};
         options.allowFallbackScan = true;
         auto status = mcap_reader_->open(*data_source_, options);
         if (!status.ok()) {

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -403,7 +403,7 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   if (!status.ok()) {
     throw std::runtime_error{std::string{"Failed to write "} +
         std::to_string(msg->serialized_data->buffer_length) +
-        " byte message to MCAP file: " + status.message};
+           " byte message to MCAP file: " + status.message};
   }
 
   /// Update metadata

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -112,16 +112,13 @@ MCAPStorage::MCAPStorage()
 
 MCAPStorage::~MCAPStorage()
 {
-  if (mcap_reader_)
-  {
+  if (mcap_reader_) {
     mcap_reader_->close();
   }
-  if (input_)
-  {
+  if (input_) {
     input_->close();
   }
-  if (mcap_writer_)
-  {
+  if (mcap_writer_) {
     mcap_writer_->close();
   }
 }
@@ -148,7 +145,7 @@ void MCAPStorage::open(
         }
         linear_view_ = std::make_unique<mcap::LinearMessageView>(mcap_reader_->readMessages());
         linear_iterator_ = std::make_unique<mcap::LinearMessageView::Iterator>(
-            linear_view_->begin());
+          linear_view_->begin());
         break;
       }
     case rosbag2_storage::storage_interfaces::IOFlag::APPEND:
@@ -258,12 +255,12 @@ bool MCAPStorage::read_and_enqueue_message()
     return false;
   }
 
-  const auto& messageView = *it;
+  const auto & messageView = *it;
   auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   msg->time_stamp = rcutils_time_point_value_t(messageView.message.logTime);
   msg->topic_name = messageView.channel->topic;
   msg->serialized_data = rosbag2_storage::make_serialized_message(
-      messageView.message.data, messageView.message.dataSize);
+    messageView.message.data, messageView.message.dataSize);
 
   // enqueue this message to be used
   next_ = msg;
@@ -351,11 +348,11 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   if (topic_it == topics_.end()) {
     throw std::runtime_error{"Unknown message topic \"" + msg->topic_name + "\""};
   }
-  const auto& topic_info = topic_it->second;
+  const auto & topic_info = topic_it->second;
 
   // Get or create a Schema reference
   mcap::SchemaId schema_id;
-  const auto& datatype = topic_info.topic_metadata.type;
+  const auto & datatype = topic_info.topic_metadata.type;
   const auto schema_it = schema_ids.find(datatype);
   if (schema_it == schema_ids.end()) {
     // TODO(jhurliman): Fetch .msg file contents. At startup, build a lookup
@@ -383,8 +380,9 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
     channel.topic = msg->topic_name;
     channel.messageEncoding = topic_info.topic_metadata.serialization_format;
     channel.schemaId = schema_id;
-    channel.metadata.emplace("offered_qos_profiles",
-        topic_info.topic_metadata.offered_qos_profiles);
+    channel.metadata.emplace(
+      "offered_qos_profiles",
+      topic_info.topic_metadata.offered_qos_profiles);
     mcap_writer_->addChannel(channel);
     channel_ids.emplace(msg->topic_name, channel.id);
     channel_id = channel.id;
@@ -398,12 +396,12 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   mcapMsg.logTime = mcap::Timestamp(std::chrono::nanoseconds(msg->time_stamp).count());
   mcapMsg.publishTime = mcapMsg.logTime;
   mcapMsg.dataSize = msg->serialized_data->buffer_length;
-  mcapMsg.data = reinterpret_cast<const std::byte*>(msg->serialized_data->buffer);
+  mcapMsg.data = reinterpret_cast<const std::byte *>(msg->serialized_data->buffer);
   const auto status = mcap_writer_->write(mcapMsg);
   if (!status.ok()) {
     throw std::runtime_error{std::string{"Failed to write "} +
-        std::to_string(msg->serialized_data->buffer_length) +
-           " byte message to MCAP file: " + status.message};
+            std::to_string(msg->serialized_data->buffer_length) +
+            " byte message to MCAP file: " + status.message};
   }
 
   /// Update metadata


### PR DESCRIPTION
Initial reader and writer implementation for MCAP files. Needs testing.

Currently, schemas are not written into recorded files (schema_id 0 is used for all channels). There is a TODO note in the code about how to proceed there, by reading message definitions from the local filesystem when starting up in write mode.
