### PR TITLE
Don't throw when READ_WRITE mode is used; add .mcap file extension to recorded files

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -32,7 +32,7 @@
 
 namespace rosbag2_storage_plugins {
 
-static const std::string FILE_EXTENSION = ".mcap";
+static const char FILE_EXTENSION[] = ".mcap";
 
 /**
  * A storage implementation for the MCAP file format.


### PR DESCRIPTION
I may be missing something, but from a cursory glance at [this code](https://github.com/ros2/rosbag2/blob/342d8ed3c1c4ae0411a4a92b60e79a728b8974b8/rosbag2_storage/src/rosbag2_storage/impl/storage_factory_impl.hpp#L108-L135), it appears that the `APPEND` mode is never used. This means we need to support `READ_WRITE`.

This also adds a `.mcap` extension to recorded file names.