### PR TITLE
[1.0.0] Use Summary section for get_metadata() and seek(), implement remaining methods

### DIFF
--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -38,7 +38,7 @@ include(${CMAKE_BINARY_DIR}/conan.cmake)
 include(FetchContent)
 fetchcontent_declare(mcap
   GIT_REPOSITORY https://github.com/foxglove/mcap.git
-  GIT_TAG 3d19068feb5a78d0073e58b1cf514bad689df94a
+  GIT_TAG 0851e316cf973c26a64773c56540efbbaf06725a
 )
 fetchcontent_makeavailable(mcap)
 

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbag2_storage_mcap</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>rosbag2 storage plugin using the MCAP file format</description>
-  <maintainer email="TODO@example.com">TODO</maintainer>
+  <maintainer email="john@foxglove.dev">John Hurliman</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rosbag2_storage_mcap/plugin_description.xml
+++ b/rosbag2_storage_mcap/plugin_description.xml
@@ -4,6 +4,6 @@
     type="rosbag2_storage_plugins::MCAPStorage"
     base_class_type="rosbag2_storage::storage_interfaces::ReadWriteInterface"
   >
-    <description>Sample plugin to write a simple linear file.</description>
+    <description>rosbag2 storage plugin using the MCAP file format</description>
   </class>
 </library>

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022, Amazon.com Inc or its Affiliates. All rights reserved.
+// Copyright 2022, Foxglove Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rosbag2_storage_mcap/src/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022, Amazon.com Inc or its Affiliates. All rights reserved.
+// Copyright 2022, Foxglove Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds Summary parsing for optimized get_metdata() and to enable seek() support. All outstanding TODO items have been addressed.

Fixes #10 and #11