### PR TITLE
Fetch dependencies using FetchContent, remove conan build dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/foxglove/mcap.git
 [submodule "vendor/zstd"]
 	path = rosbag2_storage_mcap/vendor/zstd
-	url = git@github.com:facebook/zstd.git
+	url = https://github.com/facebook/zstd.git
 [submodule "vendor/lz4"]
 	path = rosbag2_storage_mcap/vendor/lz4
-	url = git@github.com:lz4/lz4.git
+	url = https://github.com/lz4/lz4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "vendor/mcap"]
+	path = rosbag2_storage_mcap/vendor/mcap
+	url = https://github.com/foxglove/mcap.git
+[submodule "vendor/zstd"]
+	path = rosbag2_storage_mcap/vendor/zstd
+	url = git@github.com:facebook/zstd.git
+[submodule "vendor/lz4"]
+	path = rosbag2_storage_mcap/vendor/lz4
+	url = git@github.com:lz4/lz4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "vendor/mcap"]
-	path = rosbag2_storage_mcap/vendor/mcap
-	url = https://github.com/foxglove/mcap.git
-[submodule "vendor/zstd"]
-	path = rosbag2_storage_mcap/vendor/zstd
-	url = https://github.com/facebook/zstd.git
-[submodule "vendor/lz4"]
-	path = rosbag2_storage_mcap/vendor/lz4
-	url = https://github.com/lz4/lz4.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Packages in this repository:
 To build rosbag2_storage_mcap from source, in a shell that has your ROS2 environment sourced:
 
 ```bash
-git clone --recursive https://github.com/ros-tooling/rosbag2_storage_mcap.git
+git clone https://github.com/ros-tooling/rosbag2_storage_mcap.git
 cd rosbag2_storage_mcap
 colcon build
 source install/setup.bash

--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ Packages in this repository:
 
 ## Usage
 
-To build rosbag2_storage_mcap, you need [conan](https://conan.io/) installed. On most platforms this can be accomplished with `pip install conan`.
-
-In a shell that has your ROS2 environment sourced:
+To build rosbag2_storage_mcap from source, in a shell that has your ROS2 environment sourced:
 
 ```bash
-git clone https://github.com/ros-tooling/rosbag2_storage_mcap.git
+git clone --recursive https://github.com/ros-tooling/rosbag2_storage_mcap.git
 cd rosbag2_storage_mcap
 colcon build
 source install/setup.bash

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -29,6 +29,7 @@ file(GLOB ZSTD_SRCS
   vendor/zstd/lib/common/*.c
   vendor/zstd/lib/compress/*.c
   vendor/zstd/lib/decompress/*.c
+  vendor/zstd/lib/decompress/*.S
 )
 add_library(
   ${PROJECT_NAME} SHARED

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -74,7 +74,12 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE
     ament_cmake_uncrustify
+    ament_cmake_copyright
   )
+  list(APPEND ament_cmake_copyright_ADDITIONAL_EXCLUDE vendor)
+  list(APPEND ament_cmake_cpplint_ADDITIONAL_EXCLUDE vendor)
+  list(APPEND ament_cmake_cppcheck_ADDITIONAL_EXCLUDE vendor)
+  # ament_copyright(EXCLUDE vendor)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -70,17 +70,27 @@ install(
 )
 
 if(BUILD_TESTING)
+  file(GLOB _all_non_vendor_files *)
+  list(REMOVE_ITEM _all_non_vendor_files ${PROJECT_SOURCE_DIR}/vendor)
+
+  find_package(ament_cmake_copyright REQUIRED)
+  ament_copyright(${_all_non_vendor_files})
+
   set(ament_cmake_clang_format_CONFIG_FILE .clang-format)
-  find_package(ament_lint_auto REQUIRED)
-  list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_uncrustify
-    ament_cmake_copyright
-  )
-  list(APPEND ament_cmake_copyright_ADDITIONAL_EXCLUDE vendor)
-  list(APPEND ament_cmake_cpplint_ADDITIONAL_EXCLUDE vendor)
-  list(APPEND ament_cmake_cppcheck_ADDITIONAL_EXCLUDE vendor)
-  # ament_copyright(EXCLUDE vendor)
-  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_clang_format REQUIRED)
+  ament_clang_format(src)
+
+  find_package(ament_cmake_cppcheck REQUIRED)
+  ament_cppcheck(src)
+
+  find_package(ament_cmake_cpplint REQUIRED)
+  ament_cpplint(src)
+
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  ament_lint_cmake(CMakeLists.txt)
+
+  find_package(ament_cmake_xmllint REQUIRED)
+  ament_xmllint()
 endif()
 
 ament_export_libraries(${PROJECT_NAME})

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -25,70 +25,27 @@ find_package(ros_environment REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 
-# Install conan
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install conan)
-set(ENV{PATH} $ENV{HOME}/.local/bin:$ENV{PATH})
-
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
-                "${CMAKE_BINARY_DIR}/conan.cmake"
-                EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
-                TLS_VERIFY ON)
-endif()
-
-include(${CMAKE_BINARY_DIR}/conan.cmake)
-
-include(FetchContent)
-fetchcontent_declare(mcap
-  GIT_REPOSITORY https://github.com/foxglove/mcap.git
-  GIT_TAG 0851e316cf973c26a64773c56540efbbaf06725a
+file(GLOB ZSTD_SRCS
+  vendor/zstd/lib/common/*.c
+  vendor/zstd/lib/compress/*.c
+  vendor/zstd/lib/decompress/*.c
 )
-fetchcontent_makeavailable(mcap)
-
-set(MCAP_ROOT ${CMAKE_CURRENT_BINARY_DIR}/_deps/mcap-src/cpp)
-set(MCAP_INCLUDE_DIRS ${MCAP_ROOT}/mcap/include)
-
-conan_cmake_autodetect(settings)
-
-conan_cmake_install(
-  PATH_OR_REFERENCE ${MCAP_ROOT}/mcap
-  INSTALL_FOLDER ${MCAP_ROOT}/mcap/build/Release
-  BUILD missing
-  SETTINGS compiler=gcc
-  SETTINGS compiler.version=11
-  SETTINGS compiler.libcxx=libstdc++
-  SETTINGS ${settings}
-)
-
-include(${MCAP_ROOT}/mcap/build/Release/conanbuildinfo.cmake)
-conan_basic_setup()
-
 add_library(
   ${PROJECT_NAME} SHARED
   src/mcap_storage.cpp
   src/message_definition_cache.cpp
+  ${ZSTD_SRCS}
+  vendor/lz4/lib/lz4.c
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 target_include_directories(${PROJECT_NAME}
-  SYSTEM PUBLIC
-    $<BUILD_INTERFACE:${MCAP_INCLUDE_DIRS}>
-    $<INSTALL_INTERFACE:include>
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${CONAN_LIBS}
+  SYSTEM PRIVATE
+    ${PROJECT_SOURCE_DIR}/vendor/mcap/cpp/mcap/include
+    ${PROJECT_SOURCE_DIR}/vendor/lz4/lib
+    ${PROJECT_SOURCE_DIR}/vendor/zstd/lib
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=${ROS_DISTRO})
-
-install(
-  DIRECTORY
-    ${MCAP_INCLUDE_DIRS}/mcap
-  DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/include
-)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -25,25 +25,47 @@ find_package(ros_environment REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 
-file(GLOB ZSTD_SRCS
-  vendor/zstd/lib/common/*.c
-  vendor/zstd/lib/compress/*.c
-  vendor/zstd/lib/decompress/*.c
-  vendor/zstd/lib/decompress/*.S
+include(FetchContent)
+fetchcontent_declare(mcap
+  GIT_REPOSITORY https://github.com/foxglove/mcap.git
+  GIT_TAG releases/cpp/v0.1.1
+  GIT_SHALLOW 1
+)
+fetchcontent_makeavailable(mcap)
+
+fetchcontent_declare(lz4
+  GIT_REPOSITORY https://github.com/lz4/lz4.git
+  GIT_TAG v1.9.3
+  GIT_SHALLOW 1
+)
+fetchcontent_makeavailable(lz4)
+
+fetchcontent_declare(zstd
+  GIT_REPOSITORY https://github.com/facebook/zstd.git
+  GIT_TAG v1.5.2
+  GIT_SHALLOW 1
+)
+fetchcontent_makeavailable(zstd)
+
+file(GLOB _zstd_sources
+  ${zstd_SOURCE_DIR}/lib/common/*.c
+  ${zstd_SOURCE_DIR}/lib/compress/*.c
+  ${zstd_SOURCE_DIR}/lib/decompress/*.c
+  ${zstd_SOURCE_DIR}/lib/decompress/*.S
 )
 add_library(
   ${PROJECT_NAME} SHARED
   src/mcap_storage.cpp
   src/message_definition_cache.cpp
-  ${ZSTD_SRCS}
-  vendor/lz4/lib/lz4.c
+  ${_zstd_sources}
+  ${lz4_SOURCE_DIR}/lib/lz4.c
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
 target_include_directories(${PROJECT_NAME}
   SYSTEM PRIVATE
-    ${PROJECT_SOURCE_DIR}/vendor/mcap/cpp/mcap/include
-    ${PROJECT_SOURCE_DIR}/vendor/lz4/lib
-    ${PROJECT_SOURCE_DIR}/vendor/zstd/lib
+    ${mcap_SOURCE_DIR}/cpp/mcap/include
+    ${lz4_SOURCE_DIR}/lib
+    ${zstd_SOURCE_DIR}/lib
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=${ROS_DISTRO})
@@ -70,27 +92,12 @@ install(
 )
 
 if(BUILD_TESTING)
-  file(GLOB _all_non_vendor_files *)
-  list(REMOVE_ITEM _all_non_vendor_files ${PROJECT_SOURCE_DIR}/vendor)
-
-  find_package(ament_cmake_copyright REQUIRED)
-  ament_copyright(${_all_non_vendor_files})
-
   set(ament_cmake_clang_format_CONFIG_FILE .clang-format)
-  find_package(ament_cmake_clang_format REQUIRED)
-  ament_clang_format(src)
-
-  find_package(ament_cmake_cppcheck REQUIRED)
-  ament_cppcheck(src)
-
-  find_package(ament_cmake_cpplint REQUIRED)
-  ament_cpplint(src)
-
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  ament_lint_cmake(CMakeLists.txt)
-
-  find_package(ament_cmake_xmllint REQUIRED)
-  ament_xmllint()
+  find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+  )
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_export_libraries(${PROJECT_NAME})

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(rosbag2_storage_mcap)
+project(rosbag2_storage_mcap LANGUAGES C CXX ASM)
 
 # Set Release build if no build type was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -8,7 +8,6 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>python3-pip</buildtool_depend>
 
   <depend>pluginlib</depend>
   <depend>rcutils</depend>

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -4,7 +4,7 @@
   <name>rosbag2_storage_mcap</name>
   <version>0.1.1</version>
   <description>rosbag2 storage plugin using the MCAP file format</description>
-  <maintainer email="john@foxglove.dev">John Hurliman</maintainer>
+  <maintainer email="contact@foxglove.dev">Foxglove</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -15,12 +15,9 @@
   <depend>rosbag2_storage</depend>
   <depend>ament_index_cpp</depend>
 
-  <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -15,9 +15,12 @@
   <depend>rosbag2_storage</depend>
   <depend>ament_index_cpp</depend>
 
+  <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Alternative to #26 

Instead of using conan to fetch mcap & dependencies, or getting them from rosdep (which doesn't work when we need some static-only APIs and want to control the precise dependency version), we fetch the dependency sources using FetchContent.

cc @nuclearsandwich @wep21 @emersonknapp @jhurliman, please review! Thanks 🙂 