### PR TITLE
Add mcap_vendor using fetchcontent for lz4 & zstd dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Packages in this repository:
 
 ## Usage
 
-To build rosbag2_storage_mcap, you need [conan](https://conan.io/) installed. On most platforms this can be accomplished with `pip install conan`.
-
-In a shell that has your ROS2 environment sourced:
+To build rosbag2_storage_mcap from source, in a shell that has your ROS2 environment sourced:
 
 ```bash
 git clone https://github.com/ros-tooling/rosbag2_storage_mcap.git

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -52,8 +52,8 @@ macro(build_mcap_vendor)
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
 
   target_include_directories(mcap SYSTEM PRIVATE
-    ${_lz4_SOURCE_DIR/lib}
-    ${_zstd_SOURCE_DIR/lib}
+    ${lz4_SOURCE_DIR/lib}
+    ${zstd_SOURCE_DIR/lib}
   )
   target_include_directories(mcap SYSTEM PUBLIC
     "$<BUILD_INTERFACE:${_mcap_include_dir}>"

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -52,8 +52,8 @@ macro(build_mcap_vendor)
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
 
   target_include_directories(mcap SYSTEM PRIVATE
-    ${lz4_SOURCE_DIR/lib}
-    ${zstd_SOURCE_DIR/lib}
+    ${lz4_SOURCE_DIR}/lib
+    ${zstd_SOURCE_DIR}/lib
   )
   target_include_directories(mcap SYSTEM PUBLIC
     "$<BUILD_INTERFACE:${_mcap_include_dir}>"

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -21,18 +21,21 @@ macro(build_mcap_vendor)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
     GIT_TAG releases/cpp/v0.1.1
+    GIT_SHALLOW 1
   )
   fetchcontent_makeavailable(mcap)
 
   fetchcontent_declare(lz4
     GIT_REPOSITORY https://github.com/lz4/lz4.git
     GIT_TAG v1.9.3
+    GIT_SHALLOW 1
   )
   fetchcontent_makeavailable(lz4)
 
   fetchcontent_declare(zstd
     GIT_REPOSITORY https://github.com/facebook/zstd.git
     GIT_TAG v1.5.2
+    GIT_SHALLOW 1
   )
   fetchcontent_makeavailable(zstd)
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(mcap_vendor)
+project(mcap_vendor LANGUAGES C CXX ASM)
 
 ## Compile options
 if(NOT CMAKE_CXX_STANDARD)

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.5)
+project(mcap_vendor)
+
+## Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+## Dependencies
+find_package(ament_cmake REQUIRED)
+
+
+## Define vendor macro
+macro(build_mcap_vendor)
+  include(FetchContent)
+  fetchcontent_declare(mcap
+    GIT_REPOSITORY https://github.com/foxglove/mcap.git
+    GIT_TAG releases/cpp/v0.1.1
+  )
+  fetchcontent_makeavailable(mcap)
+
+  fetchcontent_declare(lz4
+    GIT_REPOSITORY https://github.com/lz4/lz4.git
+    GIT_TAG v1.9.3
+  )
+  fetchcontent_makeavailable(lz4)
+
+  fetchcontent_declare(zstd
+    GIT_REPOSITORY https://github.com/facebook/zstd.git
+    GIT_TAG v1.5.2
+  )
+  fetchcontent_makeavailable(zstd)
+
+  file(GLOB _zstd_srcs
+    ${zstd_SOURCE_DIR}/lib/common/*.c
+    ${zstd_SOURCE_DIR}/lib/compress/*.c
+    ${zstd_SOURCE_DIR}/lib/decompress/*.c
+    ${zstd_SOURCE_DIR}/lib/decompress/*.S
+  )
+  add_library(
+    mcap SHARED
+    src/main.cpp
+    ${_zstd_srcs}
+    ${lz4_SOURCE_DIR}/lib/lz4.c
+  )
+
+  set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
+
+  target_include_directories(mcap SYSTEM PUBLIC
+    "$<BUILD_INTERFACE:${_mcap_include_dir}>"
+    "$<INSTALL_INTERFACE:include>")
+
+  install(
+    DIRECTORY
+      ${_mcap_include_dir}/mcap
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/include
+  )
+
+  install(TARGETS mcap EXPORT export_mcap)
+
+  install(
+    EXPORT export_mcap
+    FILE mcap-config.cmake
+    DESTINATION share/cmake/mcap/
+    NAMESPACE "mcap_vendor::"
+    EXPORT_LINK_INTERFACE_LIBRARIES)
+endmacro()
+
+## Call vendor macro
+build_mcap_vendor()
+
+ament_export_targets(export_mcap HAS_LIBRARY_TARGET)
+
+## Tests
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+## Package
+ament_package()

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -20,22 +20,19 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG releases/cpp/v0.1.1
-    GIT_SHALLOW 1
+    GIT_TAG 743b1f8e6ac072db0649fe26ddb5d04534716fd3 # releases/cpp/v0.1.1
   )
   fetchcontent_makeavailable(mcap)
 
   fetchcontent_declare(lz4
     GIT_REPOSITORY https://github.com/lz4/lz4.git
-    GIT_TAG v1.9.3
-    GIT_SHALLOW 1
+    GIT_TAG d44371841a2f1728a3f36839fd4b7e872d0927d3 # v1.9.3
   )
   fetchcontent_makeavailable(lz4)
 
   fetchcontent_declare(zstd
     GIT_REPOSITORY https://github.com/facebook/zstd.git
-    GIT_TAG v1.5.2
-    GIT_SHALLOW 1
+    GIT_TAG e47e674cd09583ff0503f0f6defd6d23d8b718d3 # v1.5.2
   )
   fetchcontent_makeavailable(zstd)
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -51,9 +51,14 @@ macro(build_mcap_vendor)
 
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
 
+  target_include_directories(mcap SYSTEM PRIVATE
+    ${_lz4_SOURCE_DIR/lib}
+    ${_zstd_SOURCE_DIR/lib}
+  )
   target_include_directories(mcap SYSTEM PUBLIC
     "$<BUILD_INTERFACE:${_mcap_include_dir}>"
-    "$<INSTALL_INTERFACE:include>")
+    "$<INSTALL_INTERFACE:include>"
+  )
 
   install(
     DIRECTORY

--- a/mcap_vendor/package.xml
+++ b/mcap_vendor/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>mcap_vendor</name>
+  <version>0.1.1</version>
+  <description>mcap vendor package</description>
+  <maintainer email="contact@foxglove.dev">Foxglove</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mcap_vendor/src/main.cpp
+++ b/mcap_vendor/src/main.cpp
@@ -1,0 +1,3 @@
+#define MCAP_IMPLEMENTATION
+#include <mcap/reader.hpp>
+#include <mcap/writer.hpp>

--- a/mcap_vendor/src/main.cpp
+++ b/mcap_vendor/src/main.cpp
@@ -1,3 +1,2 @@
 #define MCAP_IMPLEMENTATION
-#include <mcap/reader.hpp>
-#include <mcap/writer.hpp>
+#include <mcap/mcap.hpp>

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -19,51 +19,12 @@ endif()
 set(ROS_DISTRO $ENV{ROS_DISTRO})
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(mcap_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(ros_environment REQUIRED)
 find_package(rosbag2_storage REQUIRED)
-find_package(ament_index_cpp REQUIRED)
-
-# Install conan
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install conan)
-set(ENV{PATH} $ENV{HOME}/.local/bin:$ENV{PATH})
-
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-  message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-  file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
-                "${CMAKE_BINARY_DIR}/conan.cmake"
-                EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
-                TLS_VERIFY ON)
-endif()
-
-include(${CMAKE_BINARY_DIR}/conan.cmake)
-
-include(FetchContent)
-fetchcontent_declare(mcap
-  GIT_REPOSITORY https://github.com/foxglove/mcap.git
-  GIT_TAG 0851e316cf973c26a64773c56540efbbaf06725a
-)
-fetchcontent_makeavailable(mcap)
-
-set(MCAP_ROOT ${CMAKE_CURRENT_BINARY_DIR}/_deps/mcap-src/cpp)
-set(MCAP_INCLUDE_DIRS ${MCAP_ROOT}/mcap/include)
-
-conan_cmake_autodetect(settings)
-
-conan_cmake_install(
-  PATH_OR_REFERENCE ${MCAP_ROOT}/mcap
-  INSTALL_FOLDER ${MCAP_ROOT}/mcap/build/Release
-  BUILD missing
-  SETTINGS compiler=gcc
-  SETTINGS compiler.version=11
-  SETTINGS compiler.libcxx=libstdc++
-  SETTINGS ${settings}
-)
-
-include(${MCAP_ROOT}/mcap/build/Release/conanbuildinfo.cmake)
-conan_basic_setup()
 
 add_library(
   ${PROJECT_NAME} SHARED
@@ -71,24 +32,12 @@ add_library(
   src/message_definition_cache.cpp
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
-target_include_directories(${PROJECT_NAME}
-  SYSTEM PUBLIC
-    $<BUILD_INTERFACE:${MCAP_INCLUDE_DIRS}>
-    $<INSTALL_INTERFACE:include>
-)
 
 target_link_libraries(${PROJECT_NAME}
-  ${CONAN_LIBS}
+  mcap_vendor::mcap
 )
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE ROS_DISTRO=${ROS_DISTRO})
-
-install(
-  DIRECTORY
-    ${MCAP_INCLUDE_DIRS}/mcap
-  DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/include
-)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -8,13 +8,13 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>python3-pip</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
+  <depend>mcap_vendor</depend>
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
   <depend>ros_environment</depend>
   <depend>rosbag2_storage</depend>
-  <depend>ament_index_cpp</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -18,7 +18,6 @@
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
 
-#define MCAP_IMPLEMENTATION
 #include <mcap/mcap.hpp>
 
 #include <filesystem>


### PR DESCRIPTION
Another alternative to #26 & #27. We make mcap available as a shared library, but it does not depend on lz4/zstd shared libraries.

Closes #26, closes #27

Thinking out loud: since libmcap.so now contains the lz4 & zstd symbols, does that make it impossible for another package to depend on both libmcap.so & liblz4.so?