### PR TITLE
Test Foxy & Galactic in CI, fix missing test_depends in mcap_vendor/package.xml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,28 +7,34 @@ on:
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.
-    - cron:  '0 * * * *'
+    - cron: "0 * * * *"
 
 jobs:
   build_and_test:
     strategy:
       fail-fast: false
       matrix:
-        ros: [foxy, galactic, rolling]
+        include:
+          - ros: foxy
+            ubuntu: focal
+          - ros: galactic
+            ubuntu: focal
+          - ros: rolling
+            ubuntu: jammy
 
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.os }}-latest
 
     name: ROS 2 ${{ matrix.ros }}
     steps:
-    - name: Build and run tests
-      id: action-ros-ci
-      uses: ros-tooling/action-ros-ci@v0.2
-      with:
-        package-name: rosbag2_storage_mcap
-        target-ros2-distro: ${{ matrix.ros }}
-    - uses: actions/upload-artifact@v1
-      with:
-        name: colcon-logs
-        path: ros_ws/log
+      - name: Build and run tests
+        id: action-ros-ci
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          package-name: rosbag2_storage_mcap
+          target-ros2-distro: ${{ matrix.ros }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs
+          path: ros_ws/log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,23 @@ on:
 
 jobs:
   build_and_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ros: [foxy, galactic, rolling]
+
     runs-on: ubuntu-latest
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+
+    name: ROS 2 ${{ matrix.ros }}
     steps:
     - name: Build and run tests
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.2
       with:
         package-name: rosbag2_storage_mcap
-        target-ros2-distro: rolling
+        target-ros2-distro: ${{ matrix.ros }}
     - uses: actions/upload-artifact@v1
       with:
         name: colcon-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.os }}-latest
+      image: rostooling/setup-ros-docker:ubuntu-${{ matrix.ubuntu }}-latest
 
     name: ROS 2 ${{ matrix.ros }}
     steps:

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -78,6 +78,9 @@ ament_export_targets(export_mcap HAS_LIBRARY_TARGET)
 ## Tests
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+  )
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/mcap_vendor/package.xml
+++ b/mcap_vendor/package.xml
@@ -8,6 +8,10 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mcap_vendor/src/main.cpp
+++ b/mcap_vendor/src/main.cpp
@@ -1,2 +1,16 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #define MCAP_IMPLEMENTATION
 #include <mcap/mcap.hpp>


### PR DESCRIPTION
Fix build failure for galactic and test foxy/galactic in CI.

Foxy build currently fails (#29). We can fix it in the future, or remove it if it’s impractical to fix it.