### PR TITLE
Add missing buildtool_depend on git

### DIFF
--- a/mcap_vendor/package.xml
+++ b/mcap_vendor/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
   
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This vendor package uses git to fetch sources for other packages. It should declare a dependency on that build tool.

This should address the current cause of RPM build failures for RHEL: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__mcap_vendor__rhel_8_x86_64__binary/