### PR TITLE
Add all lz4 sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             ubuntu: focal
           - ros: galactic
             ubuntu: focal
+          - ros: humble
+            ubuntu: jammy
           - ros: rolling
             ubuntu: jammy
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -42,10 +42,16 @@ macro(build_mcap_vendor)
     ${zstd_SOURCE_DIR}/lib/decompress/*.c
     ${zstd_SOURCE_DIR}/lib/decompress/*.S
   )
+
+  file(GLOB _lz4_srcs
+    ${lz4_SOURCE_DIR}/lib/*.c)
+
   add_library(
     mcap SHARED
     src/main.cpp
     ${_zstd_srcs}
+    # Commented out to show failing action, will enable in next commit
+    # ${_lz4_srcs}
     ${lz4_SOURCE_DIR}/lib/lz4.c
   )
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -50,9 +50,7 @@ macro(build_mcap_vendor)
     mcap SHARED
     src/main.cpp
     ${_zstd_srcs}
-    # Commented out to show failing action, will enable in next commit
-    # ${_lz4_srcs}
-    ${lz4_SOURCE_DIR}/lib/lz4.c
+    ${_lz4_srcs}
   )
 
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -79,6 +79,10 @@ if(BUILD_TESTING)
   # share compile defs from main library
   get_target_property(test_mcap_storage_definitions ${PROJECT_NAME} COMPILE_DEFINITIONS)
   target_compile_definitions(test_mcap_storage PRIVATE ${test_mcap_storage_definitions})
+  if(${rosbag2_cpp_VERSION} VERSION_GREATER_EQUAL 0.4.0)
+    target_compile_definitions(test_mcap_storage PRIVATE
+      ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY)
+  endif()
 endif()
 
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -75,6 +75,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
   target_link_libraries(test_mcap_storage ${PROJECT_NAME})
   ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp std_msgs)
+  # share compile defs from main library
+  get_target_property(test_mcap_storage_definitions ${PROJECT_NAME} COMPILE_DEFINITIONS)
+  target_compile_definitions(test_mcap_storage PRIVATE ${test_mcap_storage_definitions})
 endif()
 
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(rcpputils REQUIRED)
   find_package(rosbag2_cpp REQUIRED)
+  find_package(rosbag2_test_common REQUIRED)
   find_package(std_msgs REQUIRED)
 
   set(ament_cmake_clang_format_CONFIG_FILE .clang-format)
@@ -74,7 +75,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
   target_link_libraries(test_mcap_storage ${PROJECT_NAME})
-  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp std_msgs)
+  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp rosbag2_test_common std_msgs)
   # share compile defs from main library
   get_target_property(test_mcap_storage_definitions ${PROJECT_NAME} COMPILE_DEFINITIONS)
   target_compile_definitions(test_mcap_storage PRIVATE ${test_mcap_storage_definitions})

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -25,19 +25,16 @@ find_package(pluginlib REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 
-add_library(
-  ${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME} SHARED
   src/mcap_storage.cpp
   src/message_definition_cache.cpp
 )
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)
-
-target_link_libraries(${PROJECT_NAME}
-  mcap_vendor::mcap
-  pluginlib::pluginlib
-  rcutils::rcutils
-  rosbag2_storage::rosbag2_storage
-)
+ament_target_dependencies(${PROJECT_NAME}
+  mcap_vendor
+  pluginlib
+  rcutils
+  rosbag2_storage)
 
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.10.0)
   target_compile_definitions(${PROJECT_NAME} PRIVATE
@@ -65,13 +62,21 @@ install(
 )
 
 if(BUILD_TESTING)
-  set(ament_cmake_clang_format_CONFIG_FILE .clang-format)
+  find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_uncrustify
-  )
+  find_package(rcpputils REQUIRED)
+  find_package(rosbag2_cpp REQUIRED)
+  find_package(std_msgs REQUIRED)
+
+  set(ament_cmake_clang_format_CONFIG_FILE .clang-format)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
+  target_link_libraries(test_mcap_storage ${PROJECT_NAME})
+  ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp std_msgs)
 endif()
+
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -18,6 +18,9 @@
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcpputils</test_depend>
+  <test_depend>rosbag2_cpp</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rcpputils</test_depend>
   <test_depend>rosbag2_cpp</test_depend>
+  <test_depend>rosbag2_test_common</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -16,6 +16,7 @@
   <depend>rosbag2_storage</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rcpputils</test_depend>

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -71,6 +71,10 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
     auto serialized_msg = std::make_shared<rclcpp::SerializedMessage>();
     serialization.serialize_message(&msg, serialized_msg.get());
 
+    // This is really kludgy, it's due to a mismatch between types in the rclcpp serialization API
+    // and the historical Foxy serialized APIs. Prevents the hacked shared ptr from deleting the
+    // data that `serialized_bag_msg` should reasonably expect to continue existing.
+    // For this example it wouldn't matter, but in case anybody extends this test, it's for safety.
     auto serialized_bag_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     serialized_bag_msg->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
       const_cast<rcutils_uint8_array_t*>(&serialized_msg->get_rcl_serialized_message()),

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -30,11 +30,11 @@ using StorageOptions = rosbag2_cpp::StorageOptions;
 #include <string>
 
 using namespace ::testing;  // NOLINT
-using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;
+using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;t
 
 TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
-  const auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
-  const auto expected_bag = uri / "bag_0.mcap";
+  auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  auto expected_bag = uri / "bag_0.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
   rclcpp::Time time_stamp{timestamp_nanos};
   const std::string topic_name = "test_topic";

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -1,0 +1,62 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcpputils/filesystem_helper.hpp"
+#include "rosbag2_cpp/reader.hpp"
+#include "rosbag2_cpp/writer.hpp"
+#include "rosbag2_storage/storage_options.hpp"
+#include "std_msgs/msg/string.hpp"
+
+#include <gmock/gmock.h>
+
+using namespace ::testing;      // NOLINT
+using namespace rcpputils::fs;  // NOLINT
+
+TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
+  const path tmp = create_temp_directory("test_mcap_bag", current_path());
+  const path uri = tmp / "bag";
+  const path expected_bag = uri / "bag_0.mcap";
+  const int64_t timestamp_nanos = 100;  // arbitrary value
+  rclcpp::Time time_stamp{timestamp_nanos};
+  const std::string topic_name = "test_topic";
+  const std::string message_data = "Test Message 1";
+  const std::string storage_id = "mcap";
+
+  {
+    rosbag2_storage::StorageOptions options;
+    options.uri = uri.string();
+    options.storage_id = storage_id;
+
+    std_msgs::msg::String msg;
+    msg.data = message_data;
+
+    rosbag2_cpp::Writer writer{};
+    writer.open(options);
+    writer.write(msg, topic_name, time_stamp);
+
+    EXPECT_TRUE(expected_bag.is_regular_file());
+  }
+  {
+    rosbag2_storage::StorageOptions options;
+    options.uri = expected_bag.string();
+    options.storage_id = storage_id;
+
+    rosbag2_cpp::Reader reader{};
+    reader.open(options);
+    EXPECT_TRUE(reader.has_next());
+    auto msg = reader.read_next<std_msgs::msg::String>();
+    EXPECT_EQ(msg.data, message_data);
+  }
+  // rcpputils::fs::remove_all(tmp);
+}

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -22,25 +22,24 @@ using StorageOptions = rosbag2_storage::StorageOptions;
 #include "rosbag2_cpp/storage_options.hpp"
 using StorageOptions = rosbag2_cpp::StorageOptions;
 #endif
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "std_msgs/msg/string.hpp"
 
 #include <gmock/gmock.h>
 
 #include <string>
 
-using namespace ::testing;      // NOLINT
-using namespace rcpputils::fs;  // NOLINT
+using namespace ::testing;  // NOLINT
+using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;
 
-TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
-  const path tmp = create_temp_directory("test_mcap_bag", current_path());
-  const path uri = tmp / "bag";
-  const path expected_bag = uri / "bag_0.mcap";
+TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
+  const auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
+  const auto expected_bag = uri / "bag_0.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
   rclcpp::Time time_stamp{timestamp_nanos};
   const std::string topic_name = "test_topic";
   const std::string message_data = "Test Message 1";
   const std::string storage_id = "mcap";
-
   {
     StorageOptions options;
     options.uri = uri.string();
@@ -66,5 +65,4 @@ TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
     auto msg = reader.read_next<std_msgs::msg::String>();
     EXPECT_EQ(msg.data, message_data);
   }
-  rcpputils::fs::remove_all(tmp);
 }

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -15,7 +15,13 @@
 #include "rcpputils/filesystem_helper.hpp"
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/writer.hpp"
+#ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
 #include "rosbag2_storage/storage_options.hpp"
+using StorageOptions = rosbag2_storage::StorageOptions;
+#else
+#include "rosbag2_cpp/storage_options.hpp"
+using StorageOptions = rosbag2_cpp::StorageOptions;
+#endif
 #include "std_msgs/msg/string.hpp"
 
 #include <gmock/gmock.h>
@@ -36,7 +42,7 @@ TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
   const std::string storage_id = "mcap";
 
   {
-    rosbag2_storage::StorageOptions options;
+    StorageOptions options;
     options.uri = uri.string();
     options.storage_id = storage_id;
 
@@ -50,7 +56,7 @@ TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
     EXPECT_TRUE(expected_bag.is_regular_file());
   }
   {
-    rosbag2_storage::StorageOptions options;
+    StorageOptions options;
     options.uri = expected_bag.string();
     options.storage_id = storage_id;
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -20,6 +20,8 @@
 
 #include <gmock/gmock.h>
 
+#include <string>
+
 using namespace ::testing;      // NOLINT
 using namespace rcpputils::fs;  // NOLINT
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -58,5 +58,5 @@ TEST(TestMCAPStorage, can_write_and_read_basic_mcap_file) {
     auto msg = reader.read_next<std_msgs::msg::String>();
     EXPECT_EQ(msg.data, message_data);
   }
-  // rcpputils::fs::remove_all(tmp);
+  rcpputils::fs::remove_all(tmp);
 }


### PR DESCRIPTION
We specifically to need `lz4frame.c` for `LZ4F_createDecompressionContext` etc. Do as a glob to futureproof against mcap including other potential source files.

Fixes #45