### PR TITLE
Support storage-config-file Writer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ $ cd rosbag2_storage_mcap
 $ source install/local_setup.bash
 $ ros2 bag info -s mcap path/to/your_recording.mcap
 ```
+
+### ROS 2 Distro maintenance
+
+Whenever a ROS 2 distribution reaches EOL, search for comments marked COMPATIBILITY - which may no longer be needed when no new releases will be made for that distro.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This package provides a [storage plugin](https://github.com/ros2/rosbag2#storage-format-plugin-architecture) for rosbag2 which extends it with support for the [MCAP](https://mcap.dev) file format.
 
-[![ROS Foxy version](https://img.shields.io/ros/v/foxy/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#foxy)  
-[![ROS Galactic version](https://img.shields.io/ros/v/galactic/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#galactic)  
-[![ROS Humble version](https://img.shields.io/ros/v/humble/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#humble)  
+[![ROS Foxy version](https://img.shields.io/ros/v/foxy/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#foxy)
+[![ROS Galactic version](https://img.shields.io/ros/v/galactic/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#galactic)
+[![ROS Humble version](https://img.shields.io/ros/v/humble/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#humble)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/rosbag2_storage_mcap)](https://index.ros.org/p/rosbag2_storage_mcap/github-ros-tooling-rosbag2_storage_mcap/#rolling)
 
 
@@ -27,6 +27,32 @@ $ ros2 bag record -s mcap /topic1 /topic2 ...
 $ ros2 bag play -s mcap path/to/your_recording.mcap
 
 $ ros2 bag info -s mcap path/to/your_recording.mcap
+```
+
+
+### Writer Configuration
+
+To configure details of the MCAP writer for `ros2 bag record`, use the `--storage-config-file` options to provide a YAML file describing `mcap::McapWriterOptions`. See the following example providing some options.
+
+See [McapWriterOptions declaration](https://github.com/foxglove/mcap/blob/main/cpp/mcap/include/mcap/writer.hpp#L18) for all fields. Any omitted values will be left as default value.
+
+NOTE: enums are accepted as a string matching the C++ declaration, rather than by underlying integer value.
+
+
+```
+# mcap_writer_options.yml
+noCRC: false
+noChunking: false
+noMessageIndex: false
+noSummary: false
+chunkSize: 786432
+compression: "Zstd"
+compressionLevel: "Fast"
+forceCompression: false
+```
+
+```
+$ ros2 bag record -s mcap -o my_bag --all --storage-config-file mcap_writer_options.yml
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,27 @@ $ ros2 bag info -s mcap path/to/your_recording.mcap
 
 ### Writer Configuration
 
-To configure details of the MCAP writer for `ros2 bag record`, use the `--storage-config-file` options to provide a YAML file describing `mcap::McapWriterOptions`. See the following example providing some options.
+To configure details of the MCAP writer for `ros2 bag record`, use the `--storage-config-file` options to provide a YAML file describing `mcap::McapWriterOptions`. Field descriptions below copied from [McapWriterOptions declaration](https://github.com/foxglove/mcap/blob/main/cpp/mcap/include/mcap/writer.hpp#L18)
 
-See [McapWriterOptions declaration](https://github.com/foxglove/mcap/blob/main/cpp/mcap/include/mcap/writer.hpp#L18) for all fields. Any omitted values will be left as default value.
+| Field | Type / Values | Description |
+| ----- | ------------- | ----------- |
+| noCRC | bool | Disable CRC calculations for Chunks, Attachments, and the Data and Summary sections. |
+| noChunking | bool | Do write Chunks to the file, instead writing Schema, Channel, and Message records directly into the Data section. |
+| noMessageIndex | bool | Do not write Message Index records to the file. If `noSummary=true` and `noChunkIndex=false`, Chunk Index records will still be written to the Summary section, providing a coarse message index. |
+| noSummary | bool | Do not write Summary or Summary Offset sections to the file, placing the Footer record immediately after DataEnd. This can provide some speed boost to file writing and produce smaller files, at the expense of requiring a conversion process later if fast summarization or indexed access is desired. |
+| chunkSize | unsigned int | Target uncompressed Chunk payload size in bytes. Once a Chunk's uncompressed data meets or exceeds this size, the Chunk will be compressed (if compression is enabled) and written to disk. Note that smaller Chunks may be written, such as the last Chunk in the Data section. This option is ignored if `noChunking=true`. |
+| compression | "None", "Lz4", "Zstd" | Compression algorithm to use when writing Chunks. This option is ignored if `noChunking=true`. |
+| compressionLevel | "Fastest", "Fast", "Default", "Slow", "Slowest" | Compression level to use when writing Chunks. Slower generally produces smaller files, at the expense of more CPU time. These levels map to different internal settings for each compression algorithm. |
+| forceCompression | bool | By default, Chunks that do not benefit from compression will be written uncompressed. This option can be used to force compression on all Chunks. This option is ignored if `noChunking=true`. |
+| noRepeatedSchemas | bool | Advanced option. |
+| noRepeatedChannels | bool | Advanced option. |
+| noMetadataIndex | bool | Advanced option. |
+| noChunkIndex | bool | Advanced option. |
+| noStatistics | bool | Advanced option. |
+| noSummaryOffsets | bool | Advanced option. |
 
-NOTE: enums are accepted as a string matching the C++ declaration, rather than by underlying integer value.
 
+Example:
 
 ```
 # mcap_writer_options.yml

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -36,18 +36,22 @@ ament_target_dependencies(${PROJECT_NAME}
   rcutils
   rosbag2_storage)
 
-if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.10.0)
-  # COMPATIBILITY(galactic) - 0.9.x is the Galactic release
-  target_compile_definitions(${PROJECT_NAME} PRIVATE
-    ROSBAG2_STORAGE_MCAP_OVERRIDE_SEEK_METHOD
-  )
-endif()
+set(MCAP_COMPILE_DEFS)
+# COMPATIBILITY(foxy) - 0.3.x is the Foxy release
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.4.0)
-  # COMPATIBILITY(foxy) - 0.3.x is the Foxy release
-  target_compile_definitions(${PROJECT_NAME} PRIVATE
-    ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-  )
+  list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS)
+  list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY)
 endif()
+# COMPATIBILITY(galactic) - 0.9.x is the Galactic release
+if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.10.0)
+  list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_OVERRIDE_SEEK_METHOD)
+endif()
+# COMPATIBILITY(foxy, galactic) - 0.15.x is the Humble release
+if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.15.0)
+  list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP)
+endif()
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE ${MCAP_COMPILE_DEFS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -78,13 +82,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_mcap_storage test/rosbag2_storage_mcap/test_mcap_storage.cpp)
   target_link_libraries(test_mcap_storage ${PROJECT_NAME})
   ament_target_dependencies(test_mcap_storage rosbag2_storage rosbag2_cpp rosbag2_test_common std_msgs)
-  # share compile defs from main library
-  get_target_property(test_mcap_storage_definitions ${PROJECT_NAME} COMPILE_DEFINITIONS)
-  target_compile_definitions(test_mcap_storage PRIVATE ${test_mcap_storage_definitions})
-  if(${rosbag2_cpp_VERSION} VERSION_GREATER_EQUAL 0.4.0)
-    target_compile_definitions(test_mcap_storage PRIVATE
-      ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY)
-  endif()
+  target_compile_definitions(test_mcap_storage PRIVATE ${MCAP_COMPILE_DEFS})
 endif()
 
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -37,11 +37,13 @@ ament_target_dependencies(${PROJECT_NAME}
   rosbag2_storage)
 
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.10.0)
+  # COMPATIBILITY(galactic) - 0.9.x is the Galactic release
   target_compile_definitions(${PROJECT_NAME} PRIVATE
     ROSBAG2_STORAGE_MCAP_OVERRIDE_SEEK_METHOD
   )
 endif()
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.4.0)
+  # COMPATIBILITY(foxy) - 0.3.x is the Foxy release
   target_compile_definitions(${PROJECT_NAME} PRIVATE
     ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
   )

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -18,6 +18,9 @@
 #include "rosbag2_storage/ros_helper.hpp"
 #include "rosbag2_storage/storage_interfaces/read_write_interface.hpp"
 
+#ifdef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
+#include "rosbag2_storage/yaml.hpp"
+#else
 // COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
 #ifdef _WIN32
 // This is necessary because of a bug in yaml-cpp's cmake
@@ -30,6 +33,7 @@
 #include "yaml-cpp/yaml.h"
 #ifdef _WIN32
 #pragma warning(pop)
+#endif
 #endif
 
 #include <mcap/mcap.hpp>
@@ -82,13 +86,14 @@ struct McapWriterOptions : mcap::McapWriterOptions {
 
 namespace YAML {
 
-// COMPATIBILITY(foxy, galactic) - optional_assign is defined in rosbag2_storage/yaml.hpp in Humble
+#ifndef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
 template <typename T>
 void optional_assign(const Node& node, std::string field, T& assign_to) {
   if (node[field]) {
     assign_to = node[field].as<T>();
   }
 }
+#endif
 
 DECLARE_YAML_VALUE_MAP(mcap::Compression, std::string,
                        {{mcap::Compression::None, "None"},

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -62,7 +62,7 @@ namespace {
 // Simple wrapper with default constructor for use by YAML
 struct McapWriterOptions : mcap::McapWriterOptions {
   McapWriterOptions()
-      : mcap::McapWriterOptions("") {}
+      : mcap::McapWriterOptions("ros2") {}
 };
 
 }  // namespace
@@ -82,6 +82,7 @@ DECLARE_YAML_VALUE_CONVERTER(mcap::CompressionLevel,
 
 template <>
 struct convert<McapWriterOptions> {
+  // NOTE: when updating this struct, also update documentation in README.md
   static bool decode(const Node& node, McapWriterOptions& o) {
     optional_assign<bool>(node, "noCRC", o.noCRC);
     optional_assign<bool>(node, "noChunking", o.noChunking);
@@ -91,8 +92,7 @@ struct convert<McapWriterOptions> {
     optional_assign<mcap::Compression>(node, "compression", o.compression);
     optional_assign<mcap::CompressionLevel>(node, "compressionLevel", o.compressionLevel);
     optional_assign<bool>(node, "forceCompression", o.forceCompression);
-    optional_assign<std::string>(node, "profile", o.profile);
-    optional_assign<std::string>(node, "library", o.library);
+    // Intentionally omitting "profile" and "library"
     optional_assign<bool>(node, "noRepeatedSchemas", o.noRepeatedSchemas);
     optional_assign<bool>(node, "noRepeatedChannels", o.noRepeatedChannels);
     optional_assign<bool>(node, "noAttachmentIndex", o.noAttachmentIndex);
@@ -253,7 +253,6 @@ void MCAPStorage::open_impl(const std::string& uri,
         YAML::Node yaml_node = YAML::LoadFile(storage_config_uri);
         options = yaml_node.as<McapWriterOptions>();
       }
-      options.profile = "ros2";
 
       auto status = mcap_writer_->open(relative_path_, options);
       if (!status.ok()) {

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -31,14 +31,12 @@
 #include <utility>
 #include <vector>
 
-#define DECLARE_YAML_VALUE_CONVERTER(ENUM_TYPE, ...)                         \
+#define DECLARE_YAML_VALUE_CONVERTER(ENUM_TYPE, ...)                          \
   template <>                                                                 \
-  struct convert<ENUM_TYPE>                                                   \
-  {                                                                           \
-    static Node encode(const ENUM_TYPE & e)                                   \
-    {                                                                         \
+  struct convert<ENUM_TYPE> {                                                 \
+    static Node encode(const ENUM_TYPE& e) {                                  \
       static const std::pair<ENUM_TYPE, std::string> mapping[] = __VA_ARGS__; \
-      for (const auto & m : mapping) {                                        \
+      for (const auto& m : mapping) {                                         \
         if (m.first == e) {                                                   \
           return Node(m.second);                                              \
         }                                                                     \
@@ -46,11 +44,10 @@
       return Node("");                                                        \
     }                                                                         \
                                                                               \
-    static bool decode(const Node & node, ENUM_TYPE & e)                      \
-    {                                                                         \
+    static bool decode(const Node& node, ENUM_TYPE& e) {                      \
       static const std::pair<ENUM_TYPE, std::string> mapping[] = __VA_ARGS__; \
       const auto val = node.as<std::string>();                                \
-      for (const auto & m : mapping) {                                        \
+      for (const auto& m : mapping) {                                         \
         if (m.second == val) {                                                \
           e = m.first;                                                        \
           return true;                                                        \
@@ -60,37 +57,32 @@
     }                                                                         \
   };
 
-
 namespace {
 
 // Simple wrapper with default constructor for use by YAML
 struct McapWriterOptions : mcap::McapWriterOptions {
-  McapWriterOptions() : mcap::McapWriterOptions("") {}
+  McapWriterOptions()
+      : mcap::McapWriterOptions("") {}
 };
 
 }  // namespace
 
 namespace YAML {
 
-DECLARE_YAML_VALUE_CONVERTER(mcap::Compression, {
-  {mcap::Compression::None, "None"},
-  {mcap::Compression::Lz4, "Lz4"},
-  {mcap::Compression::Zstd, "Zstd"}
-});
+DECLARE_YAML_VALUE_CONVERTER(mcap::Compression, {{mcap::Compression::None, "None"},
+                                                 {mcap::Compression::Lz4, "Lz4"},
+                                                 {mcap::Compression::Zstd, "Zstd"}});
 
-DECLARE_YAML_VALUE_CONVERTER(mcap::CompressionLevel, {
-  {mcap::CompressionLevel::Fastest, "Fastest"},
-  {mcap::CompressionLevel::Fast, "Fast"},
-  {mcap::CompressionLevel::Default, "Default"},
-  {mcap::CompressionLevel::Slow, "Slow"},
-  {mcap::CompressionLevel::Slowest, "Slowest"}
-});
+DECLARE_YAML_VALUE_CONVERTER(mcap::CompressionLevel,
+                             {{mcap::CompressionLevel::Fastest, "Fastest"},
+                              {mcap::CompressionLevel::Fast, "Fast"},
+                              {mcap::CompressionLevel::Default, "Default"},
+                              {mcap::CompressionLevel::Slow, "Slow"},
+                              {mcap::CompressionLevel::Slowest, "Slowest"}});
 
-template<>
-struct convert<McapWriterOptions>
-{
-  static bool decode(const Node & node, McapWriterOptions & o)
-  {
+template <>
+struct convert<McapWriterOptions> {
+  static bool decode(const Node& node, McapWriterOptions& o) {
     optional_assign<bool>(node, "noCRC", o.noCRC);
     optional_assign<bool>(node, "noChunking", o.noChunking);
     optional_assign<bool>(node, "noMessageIndex", o.noMessageIndex);
@@ -113,7 +105,6 @@ struct convert<McapWriterOptions>
 };
 
 }  // namespace YAML
-
 
 namespace rosbag2_storage_plugins {
 
@@ -173,10 +164,8 @@ public:
   void remove_topic(const rosbag2_storage::TopicMetadata& topic) override;
 
 private:
-  void open_impl(
-    const std::string & uri,
-    rosbag2_storage::storage_interfaces::IOFlag io_flag,
-    const std::string & storage_config_uri);
+  void open_impl(const std::string& uri, rosbag2_storage::storage_interfaces::IOFlag io_flag,
+                 const std::string& storage_config_uri);
 
   bool read_and_enqueue_message();
   void ensure_summary_read();
@@ -235,11 +224,9 @@ void MCAPStorage::open(const std::string& uri,
   open_impl(uri, io_flag, "");
 }
 
-void MCAPStorage::open_impl(
-  const std::string & uri,
-  rosbag2_storage::storage_interfaces::IOFlag io_flag,
-  const std::string & storage_config_uri)
-{
+void MCAPStorage::open_impl(const std::string& uri,
+                            rosbag2_storage::storage_interfaces::IOFlag io_flag,
+                            const std::string& storage_config_uri) {
   switch (io_flag) {
     case rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY: {
       relative_path_ = uri;

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -45,9 +45,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
   const std::string topic_name = "test_topic";
   const std::string message_data = "Test Message 1";
   const std::string storage_id = "mcap";
-  // NOTE: using cumbersome APIs for Foxy compatibility,
-  // which did not yet provide plain-message API
-  // TODO(emersonknapp) - when Foxy reaches EOL this code can get cut way back
+  // COMPATIBILITY(foxy)
+  // using verbose APIs for Foxy compatibility which did not yet provide plain-message API
   rclcpp::Serialization<std_msgs::msg::String> serialization;
 
   {


### PR DESCRIPTION
Closes #35 

Add YAML deserialization to `mcap::McapWriterOptions`, so that `ros2 bag record --storage-config-file` argument can pass arbitrary configuration to the mcap writer. Most critically, this exposes chunk compression to the user.

```
$ cat writeropts.yml 
compression: "Zstd"
compressionLevel: "Fast"

$ ros2 bag record -s mcap -o mcap_compressed --all --storage-config-file writeropts.yml

$ mcap info mcap_compressed/mcap_compressed_0.mcap 
library: libmcap 0.1.2
profile: ros2
messages: 31
duration: 4.56099422s
start: 2022-08-23T18:19:46.308164974-07:00 (1661303986.308164974)
end: 2022-08-23T18:19:50.869159194-07:00 (1661303990.869159194)
compression:
        zstd: [1/1 chunks] (63.75%) 
channels:
        (1) /rosout   7 msgs (1.53 Hz)   : rcl_interfaces/msg/Log [ros2msg]  
        (2) /chat    24 msgs (5.26 Hz)   : std_msgs/msg/String [ros2msg]     
attachments: 0
```