### PR TITLE
update to 0.2.0 - enable read order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,5 @@
     "[cpp]": {
         "editor.formatOnSave": true
     },
+    "cmake.sourceDirectory": "${workspaceFolder}/rosbag2_storage_mcap",
 }

--- a/mcap_vendor/CHANGELOG.rst
+++ b/mcap_vendor/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package mcap_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.2.0 (2022-09-08)
+------------------
+* Support timestamp-ordered playback (`#50 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/50>`_)
+* Support regex topic filtering
+* Contributors: James Smith
+
 0.1.7 (2022-08-15)
 ------------------
 * Add all lz4 sources to fix undefined symbols at runtime (`#46 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/46>`_)

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -20,7 +20,7 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG releases/cpp/v0.2.0
+    GIT_TAG 24b679553674de7b04e87501abdfcde33756260f # releases/cpp/v0.2.0
   )
   fetchcontent_makeavailable(mcap)
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -20,7 +20,7 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG a06ec974f21b47f9f8425f7e70a599e3aa116d95 # releases/cpp/v0.1.2
+    GIT_TAG 74780df5f9ee326dd98b8a66233135b078274e60 # unreleased v0.2.0
   )
   fetchcontent_makeavailable(mcap)
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -20,7 +20,7 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG 74780df5f9ee326dd98b8a66233135b078274e60 # unreleased v0.2.0
+    GIT_TAG releases/cpp/v0.2.0
   )
   fetchcontent_makeavailable(mcap)
 

--- a/mcap_vendor/package.xml
+++ b/mcap_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mcap_vendor</name>
-  <version>0.1.7</version>
+  <version>0.2.0</version>
   <description>mcap vendor package</description>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
   <license>Apache License 2.0</license>

--- a/rosbag2_storage_mcap/CHANGELOG.rst
+++ b/rosbag2_storage_mcap/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package rosbag2_storage_mcap
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.2.0 (2022-09-08)
+------------------
+* Support timestamp-ordered playback (`#50 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/50>`_)
+* Support regex topic filtering
+* Contributors: James Smith
+
 0.1.7 (2022-08-15)
 ------------------
 * Add all lz4 sources to fix undefined symbols at runtime (`#46 <https://github.com/ros-tooling/rosbag2_storage_mcap/issues/46>`_)

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -50,6 +50,10 @@ endif()
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.15.0)
   list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP)
 endif()
+# COMPATIBILITY(foxy, galactic, humble) - 0.17.x is the Rolling release.
+if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.17.0)
+  list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_STORAGE_FILTER_TOPIC_REGEX)
+endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${MCAP_COMPILE_DEFS})
 

--- a/rosbag2_storage_mcap/package.xml
+++ b/rosbag2_storage_mcap/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbag2_storage_mcap</name>
-  <version>0.1.7</version>
+  <version>0.2.0</version>
   <description>rosbag2 storage plugin using the MCAP file format</description>
   <maintainer email="ros-tooling@foxglove.dev">Foxglove</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Changes

- as of v0.2.0, `McapReader` handles topic filtering through a callback in ReadMessageOptions. Use that here instead of filtering messages externally.
- Specify read order. Check for message indices first to make sure we can use LogTimeOrder, otherwise fallback to FileOrder.
- Log errors on errors within `readMessages()`.

Fixes: https://github.com/ros-tooling/rosbag2_storage_mcap/issues/50