### PR TITLE
Export lz4 and zstd dependencies for mcap_vendor

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -71,7 +71,18 @@ macro(build_mcap_vendor)
       ${CMAKE_INSTALL_PREFIX}/include
   )
 
-  install(TARGETS mcap EXPORT export_mcap)
+  install(
+    DIRECTORY
+    ${lz4_SOURCE_DIR}/lib
+    DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/include/lz4
+  )
+
+  install(
+    TARGETS mcap
+    EXPORT export_mcap
+    INCLUDES DESTINATION include include/lz4/lib
+  )
 endmacro()
 
 ## Call vendor macro

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -79,9 +79,16 @@ macro(build_mcap_vendor)
   )
 
   install(
+    DIRECTORY
+    ${zstd_SOURCE_DIR}/lib
+    DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/include/zstd
+  )
+
+  install(
     TARGETS mcap
     EXPORT export_mcap
-    INCLUDES DESTINATION include include/lz4/lib
+    INCLUDES DESTINATION include include/lz4/lib include/zstd/lib
   )
 endmacro()
 

--- a/mcap_vendor/src/main.cpp
+++ b/mcap_vendor/src/main.cpp
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define MCAP_IMPLEMENTATION
 #include <mcap/mcap.hpp>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define MCAP_IMPLEMENTATION
 #include "rcutils/logging_macros.h"
 #include "rosbag2_storage/metadata_io.hpp"
 #include "rosbag2_storage/ros_helper.hpp"


### PR DESCRIPTION
- Closes #55 

Exporting dependencies from header files from `lz4` and `zstd` libraries.
Note: It turns out that on my local machine include for`zstd.h` was taken from local `usr/include/zstd.h` instead of the  downloaded version specified in `mcap_vendor` package.
I have to export `zstd` header files the same way as `lz4` since CI was failing.
It also will solve some potential hidden compilation errors in future if our dependent `zstd` library will diverge from installed by default with Linux distro.