### PR TITLE
Some minor improvements in rosbag2_storage_mcap after review

### DIFF
--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -49,9 +49,10 @@ private:
   std::string name_;
 
 public:
-  explicit DefinitionNotFoundError(const std::string& name)
-      : name_(name) {}
-  const char* what() const throw() {
+  explicit DefinitionNotFoundError(std::string name)
+      : name_(std::move(name)) {}
+
+  const char* what() const noexcept override {
     return name_.c_str();
   }
 };

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -67,7 +67,7 @@ static std::set<std::string> parse_idl_dependencies(const std::string& text) {
 
   for (std::sregex_iterator iter(text.begin(), text.end(), IDL_FIELD_TYPE_REGEX);
        iter != std::sregex_iterator(); ++iter) {
-    dependencies.insert(std::move((*iter)[1]));
+    dependencies.insert((*iter)[1]);
   }
   return dependencies;
 }


### PR DESCRIPTION
Some minor improvements in `rosbag2_storage_mcap` after review.
Better latter than never :smile: 

1. Fixed some findings from Clang-Tidy
1. Some renames according to the ROS2 coding style
1. Add default initialization for member variables
1. Moved code responsible for adding schema and channel from `write(msg)` to `create_topic(topic)` method to reduce performance burden on first message write and in lieu to preparation for moving schema collection process to upper `SequentialWriter` layer.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>