### PR TITLE
Cleanup in `mcap_vendor` package

### DIFF
--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -55,7 +55,13 @@ macro(build_mcap_vendor)
     DESTINATION include/${PROJECT_NAME}
   )
 
-  install(TARGETS mcap EXPORT mcap)
+  install(
+    TARGETS mcap
+    EXPORT mcap
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+  )
 endmacro()
 
 ## Call vendor macro

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -34,36 +34,36 @@ macro(build_mcap_vendor)
   file(GLOB _lz4_srcs
     ${lz4_SOURCE_DIR}/lib/*.c)
 
-  add_library(${PROJECT_NAME} SHARED
+  add_library(mcap SHARED
     src/main.cpp
     ${_lz4_srcs}
   )
 
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
 
-  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+  target_include_directories(mcap PRIVATE
     ${lz4_SOURCE_DIR}/lib
   )
-  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+  target_include_directories(mcap PUBLIC
     "$<BUILD_INTERFACE:${_mcap_include_dir}>"
-    "$<INSTALL_INTERFACE:include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   )
-  ament_target_dependencies(${PROJECT_NAME} zstd)
+  ament_target_dependencies(mcap zstd)
 
   install(
     DIRECTORY ${_mcap_include_dir}/mcap
     DESTINATION include/${PROJECT_NAME}
   )
 
-  install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME})
+  install(TARGETS mcap EXPORT mcap)
 endmacro()
 
 ## Call vendor macro
 build_mcap_vendor()
 
 ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME}  HAS_LIBRARY_TARGET)
+ament_export_libraries(mcap)
+ament_export_targets(mcap  HAS_LIBRARY_TARGET)
 ament_export_dependencies(zstd_vendor zstd)
 
 ## Package

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(mcap_vendor LANGUAGES C CXX ASM)
 
+## Dependencies
+find_package(ament_cmake REQUIRED)
+find_package(zstd_vendor REQUIRED)
+find_package(zstd REQUIRED)
+
 ## Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -10,12 +15,6 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
-
-## Dependencies
-find_package(ament_cmake REQUIRED)
-find_package(zstd_vendor REQUIRED)
-find_package(zstd REQUIRED)
-
 
 ## Define vendor macro
 macro(build_mcap_vendor)
@@ -35,48 +34,37 @@ macro(build_mcap_vendor)
   file(GLOB _lz4_srcs
     ${lz4_SOURCE_DIR}/lib/*.c)
 
-  add_library(
-    mcap SHARED
+  add_library(${PROJECT_NAME} SHARED
     src/main.cpp
     ${_lz4_srcs}
   )
 
   set(_mcap_include_dir ${mcap_SOURCE_DIR}/cpp/mcap/include)
 
-  target_include_directories(mcap SYSTEM PRIVATE
+  target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
     ${lz4_SOURCE_DIR}/lib
   )
-  target_include_directories(mcap SYSTEM PUBLIC
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
     "$<BUILD_INTERFACE:${_mcap_include_dir}>"
     "$<INSTALL_INTERFACE:include>"
   )
-  ament_target_dependencies(mcap zstd)
+  ament_target_dependencies(${PROJECT_NAME} zstd)
 
   install(
-    DIRECTORY
-      ${_mcap_include_dir}/mcap
-    DESTINATION
-      ${CMAKE_INSTALL_PREFIX}/include
+    DIRECTORY ${_mcap_include_dir}/mcap
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
   )
 
-  install(TARGETS mcap EXPORT export_mcap)
+  install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME})
 endmacro()
 
 ## Call vendor macro
 build_mcap_vendor()
 
-ament_export_targets(export_mcap HAS_LIBRARY_TARGET)
-
+ament_export_include_directories(${_mcap_include_dir})
+ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(${PROJECT_NAME}  HAS_LIBRARY_TARGET)
 ament_export_dependencies(zstd_vendor zstd)
-
-## Tests
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    ament_cmake_uncrustify
-  )
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ## Package
 ament_package()

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -68,7 +68,6 @@ endmacro()
 build_mcap_vendor()
 
 ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_libraries(mcap)
 ament_export_targets(mcap  HAS_LIBRARY_TARGET)
 ament_export_dependencies(zstd_vendor zstd)
 

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -68,7 +68,7 @@ endmacro()
 build_mcap_vendor()
 
 ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_targets(mcap  HAS_LIBRARY_TARGET)
+ament_export_targets(mcap HAS_LIBRARY_TARGET)
 ament_export_dependencies(zstd_vendor zstd)
 
 ## Package

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -52,7 +52,7 @@ macro(build_mcap_vendor)
 
   install(
     DIRECTORY ${_mcap_include_dir}/mcap
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+    DESTINATION include/${PROJECT_NAME}
   )
 
   install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME})
@@ -61,7 +61,7 @@ endmacro()
 ## Call vendor macro
 build_mcap_vendor()
 
-ament_export_include_directories(${_mcap_include_dir})
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME}  HAS_LIBRARY_TARGET)
 ament_export_dependencies(zstd_vendor zstd)

--- a/mcap_vendor/package.xml
+++ b/mcap_vendor/package.xml
@@ -12,10 +12,6 @@
 
   <depend>zstd_vendor</depend>
 
-  <test_depend>ament_cmake_clang_format</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -36,7 +36,7 @@
 #endif
 #endif
 
-#include <mcap_vendor/mcap/mcap.hpp>
+#include <mcap/mcap.hpp>
 
 #include <algorithm>
 #include <filesystem>

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -36,7 +36,7 @@
 #endif
 #endif
 
-#include <mcap/mcap.hpp>
+#include <mcap_vendor/mcap/mcap.hpp>
 
 #include <algorithm>
 #include <filesystem>


### PR DESCRIPTION
- Use `${PROJECT_NAME}` instead of confusing `mcap` for library name and exporting target, to be consistent with all other packages in ROS2.

- Add export for path to the `mcap` includes and export for mcap_vendor library. It was an issue in downstream packages that `mcap/mcap.hpp` was not visible since we were not exporting path to it explicitly.

- Removed test section with linters for `mcap_vendor` package. Since package itself doesn't contain any tests and its own code and we shouldn't run linters on any third party code. Prevent CI failures.

Signed-off-by: Michael Orlov <michael.orlov@apex.ai>