### PR TITLE
Configure write buffer behaviour with storage config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ $ ros2 bag info -s mcap path/to/your_recording.mcap
 
 ### Writer Configuration
 
-To configure details of the MCAP writer for `ros2 bag record`, use the `--storage-config-file` options to provide a YAML file describing `mcap::McapWriterOptions`. Field descriptions below copied from [McapWriterOptions declaration](https://github.com/foxglove/mcap/blob/main/cpp/mcap/include/mcap/writer.hpp#L18)
+To configure details of the MCAP writer for `ros2 bag record`, use the `--storage-config-file` options to provide a YAML file with the fields described below. Field descriptions below are mostly copied from [McapWriterOptions declaration](https://github.com/foxglove/mcap/blob/main/cpp/mcap/include/mcap/writer.hpp#L18), with some additional fields for controlling write buffering.
 
 | Field | Type / Values | Description |
 | ----- | ------------- | ----------- |
-| noCRC | bool | Disable CRC calculations for Chunks, Attachments, and the Data and Summary sections. |
+| bufferCapacity | unsigned int | the size of the write buffer in bytes. Defaults to 1kB. |
+| syncAfterWrite | bool | if true, the writer will sync all writes to the physical storage medium after each write. | if true, flush all data to disk after every McapStorage::write() call. **NOTE** This will cause many small chunks to be written, if using a chunk size smaller than the rosbag2 cache size. Any partial chunk still open at the end of a McapStorage::write() call is closed and written to the file early. To avoid this, set chunkSize to a larger value than your cache size. This ensures that each batch from rosbag2_transport gets written as its own chunk. |
+| bufferEntireBatch | bool | if true, `bufferCapacity` is ignored and the messages from each write() call are buffered together before writing them all at once. |
+| noChunkCRC | bool | Disable CRC calculations for Chunks. |
+| noAttachmentCRC | bool | Disable CRC calculations for Attachments. |
+| enableDataCRC | bool | Enable a CRC for the entire data section. This is useful for `noChunking: true`, but otherwise mostly redundant. |
 | noChunking | bool | Do write Chunks to the file, instead writing Schema, Channel, and Message records directly into the Data section. |
 | noMessageIndex | bool | Do not write Message Index records to the file. If `noSummary=true` and `noChunkIndex=false`, Chunk Index records will still be written to the Summary section, providing a coarse message index. |
 | noSummary | bool | Do not write Summary or Summary Offset sections to the file, placing the Footer record immediately after DataEnd. This can provide some speed boost to file writing and produce smaller files, at the expense of requiring a conversion process later if fast summarization or indexed access is desired. |

--- a/mcap_vendor/CMakeLists.txt
+++ b/mcap_vendor/CMakeLists.txt
@@ -22,7 +22,7 @@ macro(build_mcap_vendor)
   include(FetchContent)
   fetchcontent_declare(mcap
     GIT_REPOSITORY https://github.com/foxglove/mcap.git
-    GIT_TAG 24b679553674de7b04e87501abdfcde33756260f # releases/cpp/v0.2.0
+    GIT_TAG 0aec14adccb1b39de835251cf0902a77ed41dcad # unreleased
   )
   fetchcontent_makeavailable(mcap)
 

--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(rosbag2_storage REQUIRED)
 add_library(${PROJECT_NAME} SHARED
   src/mcap_storage.cpp
   src/message_definition_cache.cpp
+  src/buffered_writer.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/buffered_writer.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/buffered_writer.hpp
@@ -1,0 +1,62 @@
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef ROSBAG2_STORAGE_MCAP__BUFFERED_WRITER_HPP_
+#define ROSBAG2_STORAGE_MCAP__BUFFERED_WRITER_HPP_
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+#include <mcap/mcap.hpp>
+
+namespace rosbag2_storage_mcap {
+
+class BufferedWriter final : public mcap::IWritable {
+public:
+  ~BufferedWriter() override;
+
+  /**
+   * @brief opens a file for writing.
+   * 
+   * @param filename The path to the file to write.
+   * @param bufferSize if std::nullopt, the buffer will grow until flush() is called.
+   *   otherwise, the buffer will be written to the file if it exceeds this size.
+   * @return true if the file opened successfully.
+   * @return false if the file could not be opened for writing.
+   */
+  bool open(std::string_view filename, std::optional<size_t> bufferSize);
+  /**
+   * @brief write any buffered bytes to disk and empty the buffer. Does not imply fsync().
+   */
+  void flush();
+  /**
+   * @brief asks the OS to block until all bytes are actually written to the underlying storage
+   * medium. Equivalent to `fsync()` on Unix-like systems, or `FlushFileBuffers()` on Windows.
+   * 
+   */
+  bool syncToDisk();
+
+  void handleWrite(const std::byte* data, uint64_t size) override;
+  void end() override;
+  uint64_t size() const override;
+
+private:
+  std::vector<std::byte> buffer_;
+  std::optional<size_t> bufferCapacity_;
+  std::FILE* file_ = nullptr;
+  uint64_t size_ = 0;
+};
+
+}  // namespace rosbag2_storage_mcap
+
+#endif  // ROSBAG2_STORAGE_MCAP__BUFFERED_WRITER_HPP_

--- a/rosbag2_storage_mcap/src/buffered_writer.cpp
+++ b/rosbag2_storage_mcap/src/buffered_writer.cpp
@@ -1,0 +1,98 @@
+
+// Copyright 2022, Foxglove Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "rosbag2_storage_mcap/buffered_writer.hpp"
+#ifdef _WIN32
+#include <fileapi.h>
+#else
+#include <unistd.h>
+#include <stdio.h>
+#endif
+
+namespace rosbag2_storage_mcap {
+
+BufferedWriter::~BufferedWriter() {
+  end();
+}
+
+bool BufferedWriter::open(std::string_view filename, std::optional<size_t> bufferCapacity) {
+  end();
+  file_ = std::fopen(filename.data(), "wb");
+  if (!file_) {
+    // add ros log
+    return false;
+  }
+  bufferCapacity_ = bufferCapacity;
+  if (bufferCapacity) {
+    buffer_.reserve(*bufferCapacity);
+  }
+  return true;
+}
+
+void BufferedWriter::handleWrite(const std::byte* data, uint64_t size) {
+  assert(file_);
+
+  if (bufferCapacity_ != std::nullopt) {
+    // If this will overflow the buffer, flush it
+    if (buffer_.size() > 0 && buffer_.size() + size > *bufferCapacity_) {
+      flush();
+    }
+    // Append to the buffer if it will fit, otherwise directly write
+    if (buffer_.size() + size <= bufferCapacity_) {
+      buffer_.insert(buffer_.end(), data, data + size);
+    } else {
+      const size_t written = std::fwrite(data, 1, size, file_);
+      (void)written;
+      assert(written == size);
+    }
+  } else {
+    buffer_.insert(buffer_.end(), data, data + size);
+  }
+
+  size_ += size;
+}
+
+void BufferedWriter::flush() {
+  const size_t written = std::fwrite(buffer_.data(), 1, buffer_.size(), file_);
+  (void)written;
+  assert(written == buffer_.size());
+  buffer_.clear();
+}
+
+bool BufferedWriter::syncToDisk() {
+#ifdef _WIN32
+  return FlushFileBuffers((HANDLE) _get_osfhandle(_fileno(file_))) != 0;
+#else
+  return fsync(fileno(file_)) == 0;
+#endif
+}
+
+void BufferedWriter::end() {
+  if (file_) {
+    if (buffer_.size() > 0) {
+      std::fwrite(buffer_.data(), 1, buffer_.size(), file_);
+    }
+
+    std::fclose(file_);
+    file_ = nullptr;
+  }
+  buffer_.clear();
+  size_ = 0;
+}
+
+uint64_t BufferedWriter::size() const {
+  return size_;
+}
+
+}  // namespace rosbag2_storage_mcap

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -96,7 +96,7 @@ struct WriteBufferingOptions {
   /// chunk.
   bool syncAfterWrite = false;
   /// @brief  if true, bufferCapacity is ignored and the messages from each write() call are
-  //// buffered together before writing them all at once.
+  /// buffered together before writing them all at once.
   bool bufferEntireBatch = false;
 };
 
@@ -317,7 +317,6 @@ void MCAPStorage::open_impl(const std::string& uri,
       relative_path_ = uri + FILE_EXTENSION;
 
       mcap_writer_ = std::make_unique<mcap::McapWriter>();
-      buffered_writer_ = std::make_unique<rosbag2_storage_mcap::BufferedWriter>();
       McapWriterOptions mcap_writer_options;
       WriteBufferingOptions write_buffering_options;
       if (!storage_config_uri.empty()) {

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -113,7 +113,9 @@ template <>
 struct convert<McapWriterOptions> {
   // NOTE: when updating this struct, also update documentation in README.md
   static bool decode(const Node& node, McapWriterOptions& o) {
-    optional_assign<bool>(node, "noCRC", o.noCRC);
+    optional_assign<bool>(node, "noChunkCRC", o.noChunkCRC);
+    optional_assign<bool>(node, "noAttachmentCRC", o.noAttachmentCRC);
+    optional_assign<bool>(node, "enableDataCRC", o.enableDataCRC);
     optional_assign<bool>(node, "noChunking", o.noChunking);
     optional_assign<bool>(node, "noMessageIndex", o.noMessageIndex);
     optional_assign<bool>(node, "noSummary", o.noSummary);

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -317,6 +317,7 @@ void MCAPStorage::open_impl(const std::string& uri,
       relative_path_ = uri + FILE_EXTENSION;
 
       mcap_writer_ = std::make_unique<mcap::McapWriter>();
+      buffered_writer_ = std::make_unique<rosbag2_storage_mcap::BufferedWriter>();
       McapWriterOptions mcap_writer_options;
       WriteBufferingOptions write_buffering_options;
       if (!storage_config_uri.empty()) {


### PR DESCRIPTION
Adds the ability to control write buffer behaviour with the storage config. This adds 3 options, described here:

To do this, I've appropriated the `mcap::FileWriter` class and created `rosbag2_storage_mcap::BufferedWriter`, which exposes some additional methods to flush all buffers and to `fsync` the underlying file descriptor.

Depends on https://github.com/foxglove/mcap/pull/678

Fixes #65 