### PR TITLE
open: set defaults for SQLite plugin parity

### DIFF
--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -312,6 +312,9 @@ void MCAPStorage::open_impl(const std::string& uri, const std::string& preset_pr
 
       mcap_writer_ = std::make_unique<mcap::McapWriter>();
       McapWriterOptions options;
+      // Set defaults for the rosbag2 storage plugin specifically.
+      options.noChunkCRC = true;
+      options.compression = mcap::Compression::None;
       // Set options from preset profile first
       if (!preset_profile.empty()) {
         SetOptionsForPreset(preset_profile, options);


### PR DESCRIPTION
When opening a new MCAP for writing, set the defaults for McapWriterOptions so that the MCAP plugin writes files that are:

1. indexed
2. uncompressed
3. without CRCs

This is the closest feature set to the existing SQLite storage plugin. This also makes MCAP write throughput and message drop performance equivalent or better than the SQLite storage plugin in their default configurations.