### PR TITLE
Fix compile flags to work on `rosbag_storage:0.17.x`

### DIFF
--- a/rosbag2_storage_mcap/CMakeLists.txt
+++ b/rosbag2_storage_mcap/CMakeLists.txt
@@ -55,9 +55,12 @@ endif()
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.15.0)
   list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP)
 endif()
-# COMPATIBILITY(foxy, galactic, humble) - 0.17.x is the Rolling release.
+# COMPATIBILITY(foxy, galactic, humble, rolling:0.17.x)
 if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.17.0)
   list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_STORAGE_FILTER_TOPIC_REGEX)
+endif()
+# COMPATIBILITY(foxy, galactic, humble, rolling:0.17.x, rolling:0.18.x)
+if(${rosbag2_storage_VERSION} VERSION_GREATER_EQUAL 0.18.0)
   list(APPEND MCAP_COMPILE_DEFS ROSBAG2_STORAGE_MCAP_HAS_SET_READ_ORDER)
 endif()
 


### PR DESCRIPTION
This fixes the compile flags for rolling, which has two versions -- one that does not support read order (0.17.x) and one that does support read order (0.18.x). I can confirm that this now gives me a clean build on my workspace, which is locked to `0.17.x`:

Previous behavior:
```
asymingt@machinehead:~/development/mcap_ws$ colcon build
Starting >>> mcap_vendor
Starting >>> rosbag2_storage_mcap_testdata
Finished <<< mcap_vendor [0.23s]                                                                                 
Finished <<< rosbag2_storage_mcap_testdata [1.43s]                     
Starting >>> rosbag2_storage_mcap
--- stderr: rosbag2_storage_mcap                             
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:181:46: error: ‘ReadOrder’ in namespace ‘rosbag2_storage’ does not name a type
  181 |   void set_read_order(const rosbag2_storage::ReadOrder&) override;
      |                                              ^~~~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:181:8: error: ‘void rosbag2_storage_plugins::MCAPStorage::set_read_order(const int&)’ marked ‘override’, but does not override
  181 |   void set_read_order(const rosbag2_storage::ReadOrder&) override;
      |        ^~~~~~~~~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:499:57: error: ‘ReadOrder’ in namespace ‘rosbag2_storage’ does not name a type
  499 | void MCAPStorage::set_read_order(const rosbag2_storage::ReadOrder& read_order) {
      |                                                         ^~~~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp: In member function ‘void rosbag2_storage_plugins::MCAPStorage::set_read_order(const int&)’:
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:501:22: error: request for member ‘sort_by’ in ‘read_order’, which is of non-class type ‘const int’
  501 |   switch (read_order.sort_by) {
      |                      ^~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:502:27: error: ‘rosbag2_storage::ReadOrder’ has not been declared
  502 |     case rosbag2_storage::ReadOrder::ReceivedTimestamp:
      |                           ^~~~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:503:22: error: request for member ‘reverse’ in ‘read_order’, which is of non-class type ‘const int’
  503 |       if (read_order.reverse) {
      |                      ^~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:509:27: error: ‘rosbag2_storage::ReadOrder’ has not been declared
  509 |     case rosbag2_storage::ReadOrder::File:
      |                           ^~~~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:510:23: error: request for member ‘reverse’ in ‘read_order’, which is of non-class type ‘const int’
  510 |       if (!read_order.reverse) {
      |                       ^~~~~~~
/usr/local/home/asymingt/development/mcap_ws/src/rosbag2_storage_mcap/rosbag2_storage_mcap/src/mcap_storage.cpp:516:27: error: ‘rosbag2_storage::ReadOrder’ has not been declared
  516 |     case rosbag2_storage::ReadOrder::PublishedTimestamp:
      |                           ^~~~~~~~~
make[2]: *** [CMakeFiles/rosbag2_storage_mcap.dir/build.make:63: CMakeFiles/rosbag2_storage_mcap.dir/src/mcap_storage.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:154: CMakeFiles/rosbag2_storage_mcap.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< rosbag2_storage_mcap [2.59s, exited with code 2]

Summary: 2 packages finished [4.34s]
  1 package failed: rosbag2_storage_mcap
  1 package had stderr output: rosbag2_storage_mcap
```

New behavior:
```
asymingt@machinehead:~/development/mcap_ws$ colcon build
Starting >>> mcap_vendor
Starting >>> rosbag2_storage_mcap_testdata
Finished <<< mcap_vendor [0.22s]                                                                                 
Finished <<< rosbag2_storage_mcap_testdata [1.46s]                     
Starting >>> rosbag2_storage_mcap
Finished <<< rosbag2_storage_mcap [7.16s]                     

Summary: 3 packages finished [8.92s]
```
