### PR TITLE
Update clang-format rules to fit ROS 2 style guide

### DIFF
--- a/rosbag2_storage_mcap/.clang-format
+++ b/rosbag2_storage_mcap/.clang-format
@@ -9,6 +9,7 @@ BraceWrapping:
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: true
+  AfterEnum: true
 BreakBeforeBraces: Custom
 ColumnLimit: 100
 ConstructorInitializerIndentWidth: 0

--- a/rosbag2_storage_mcap/.clang-format
+++ b/rosbag2_storage_mcap/.clang-format
@@ -6,16 +6,24 @@ BasedOnStyle: Google
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: Empty
 AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
 TabWidth: 2
 ContinuationIndentWidth: 2
 UseTab: Never
 BreakConstructorInitializers: BeforeComma
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
 ColumnLimit: 100
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 DerivePointerAlignment: false
 FixNamespaceComments: true
-PointerAlignment: Left
-ReflowComments: true
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
 SortIncludes: true
 IndentPPDirectives: BeforeHash
 
@@ -28,3 +36,4 @@ IncludeCategories:
     Priority: 3
   - Regex: "^<.*"
     Priority: 4
+...

--- a/rosbag2_storage_mcap/.clang-format
+++ b/rosbag2_storage_mcap/.clang-format
@@ -1,9 +1,15 @@
 ---
 Language: Cpp
+Standard: c++17
 BasedOnStyle: Google
 
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
 AccessModifierOffset: -2
-AlignAfterOpenBracket: AlwaysBreak
+TabWidth: 2
+ContinuationIndentWidth: 2
+UseTab: Never
+BreakConstructorInitializers: BeforeComma
 BraceWrapping:
   AfterClass: true
   AfterFunction: true
@@ -12,10 +18,20 @@ BraceWrapping:
   AfterEnum: true
 BreakBeforeBraces: Custom
 ColumnLimit: 100
-ConstructorInitializerIndentWidth: 0
-ContinuationIndentWidth: 2
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 DerivePointerAlignment: false
+FixNamespaceComments: true
 PointerAlignment: Middle
 ReflowComments: false
+SortIncludes: true
 IndentPPDirectives: BeforeHash
-...
+
+IncludeCategories:
+  - Regex: '^"'
+    Priority: 1
+  - Regex: "^<mcap"
+    Priority: 2
+  - Regex: "^<.*/"
+    Priority: 3
+  - Regex: "^<.*"
+    Priority: 4

--- a/rosbag2_storage_mcap/.clang-format
+++ b/rosbag2_storage_mcap/.clang-format
@@ -17,4 +17,5 @@ ContinuationIndentWidth: 2
 DerivePointerAlignment: false
 PointerAlignment: Middle
 ReflowComments: false
+IndentPPDirectives: BeforeHash
 ...

--- a/rosbag2_storage_mcap/.clang-format
+++ b/rosbag2_storage_mcap/.clang-format
@@ -1,16 +1,9 @@
 ---
 Language: Cpp
-Standard: c++17
 BasedOnStyle: Google
 
-AllowShortFunctionsOnASingleLine: Empty
-AllowShortLambdasOnASingleLine: Empty
 AccessModifierOffset: -2
 AlignAfterOpenBracket: AlwaysBreak
-TabWidth: 2
-ContinuationIndentWidth: 2
-UseTab: Never
-BreakConstructorInitializers: BeforeComma
 BraceWrapping:
   AfterClass: true
   AfterFunction: true
@@ -18,22 +11,9 @@ BraceWrapping:
   AfterStruct: true
 BreakBeforeBraces: Custom
 ColumnLimit: 100
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-DerivePointerAlignment: false
-FixNamespaceComments: true
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
 DerivePointerAlignment: false
 PointerAlignment: Middle
 ReflowComments: false
-SortIncludes: true
-IndentPPDirectives: BeforeHash
-
-IncludeCategories:
-  - Regex: '^"'
-    Priority: 1
-  - Regex: "^<mcap"
-    Priority: 2
-  - Regex: "^<.*/"
-    Priority: 3
-  - Regex: "^<.*"
-    Priority: 4
 ...

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -15,13 +15,13 @@
 #ifndef ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 #define ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 
-#include "visibility_control.hpp"
-
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+
+#include "visibility_control.hpp"
 
 namespace rosbag2_storage_mcap::internal
 {
@@ -56,15 +56,9 @@ private:
   std::string name_;
 
 public:
-  explicit DefinitionNotFoundError(std::string name)
-      : name_(std::move(name))
-  {
-  }
+  explicit DefinitionNotFoundError(std::string name) : name_(std::move(name)) {}
 
-  const char * what() const noexcept override
-  {
-    return name_.c_str();
-  }
+  const char * what() const noexcept override { return name_.c_str(); }
 };
 
 class MessageDefinitionCache final

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -15,13 +15,13 @@
 #ifndef ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 #define ROSBAG2_STORAGE_MCAP__MESSAGE_DEFINITION_CACHE_HPP_
 
+#include "visibility_control.hpp"
+
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-
-#include "visibility_control.hpp"
 
 namespace rosbag2_storage_mcap::internal
 {
@@ -56,9 +56,15 @@ private:
   std::string name_;
 
 public:
-  explicit DefinitionNotFoundError(std::string name) : name_(std::move(name)) {}
+  explicit DefinitionNotFoundError(std::string name)
+      : name_(std::move(name))
+  {
+  }
 
-  const char * what() const noexcept override { return name_.c_str(); }
+  const char * what() const noexcept override
+  {
+    return name_.c_str();
+  }
 };
 
 class MessageDefinitionCache final
@@ -96,8 +102,8 @@ private:
 };
 
 ROSBAG2_STORAGE_MCAP_PUBLIC
-std::set<std::string> parse_dependencies(
-  Format format, const std::string & text, const std::string & package_context);
+std::set<std::string> parse_dependencies(Format format, const std::string & text,
+                                         const std::string & package_context);
 
 }  // namespace rosbag2_storage_mcap::internal
 

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -25,8 +25,8 @@
 
 namespace rosbag2_storage_mcap::internal
 {
-
-enum struct Format {
+enum struct Format
+{
   IDL,
   MSG,
 };

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/message_definition_cache.hpp
@@ -23,43 +23,52 @@
 #include <unordered_set>
 #include <utility>
 
-namespace rosbag2_storage_mcap::internal {
+namespace rosbag2_storage_mcap::internal
+{
 
 enum struct Format {
   IDL,
   MSG,
 };
 
-struct MessageSpec {
-  MessageSpec(Format format, std::string text, const std::string& package_context);
+struct MessageSpec
+{
+  MessageSpec(Format format, std::string text, const std::string & package_context);
   const std::set<std::string> dependencies;
   const std::string text;
   Format format;
 };
 
-struct DefinitionIdentifier {
+struct DefinitionIdentifier
+{
   Format format;
   std::string package_resource_name;
 
-  bool operator==(const DefinitionIdentifier& di) const {
+  bool operator==(const DefinitionIdentifier & di) const
+  {
     return (format == di.format) && (package_resource_name == di.package_resource_name);
   }
 };
 
-class DefinitionNotFoundError : public std::exception {
+class DefinitionNotFoundError : public std::exception
+{
 private:
   std::string name_;
 
 public:
   explicit DefinitionNotFoundError(std::string name)
-      : name_(std::move(name)) {}
+      : name_(std::move(name))
+  {
+  }
 
-  const char* what() const noexcept override {
+  const char * what() const noexcept override
+  {
     return name_.c_str();
   }
 };
 
-class MessageDefinitionCache final {
+class MessageDefinitionCache final
+{
 public:
   /**
    * Concatenate the message definition with its dependencies into a self-contained schema.
@@ -70,11 +79,13 @@ public:
    * package resource name.
    */
   ROSBAG2_STORAGE_MCAP_PUBLIC
-  std::pair<Format, std::string> get_full_text(const std::string& package_resource_name);
+  std::pair<Format, std::string> get_full_text(const std::string & package_resource_name);
 
 private:
-  struct DefinitionIdentifierHash {
-    std::size_t operator()(const DefinitionIdentifier& di) const {
+  struct DefinitionIdentifierHash
+  {
+    std::size_t operator()(const DefinitionIdentifier & di) const
+    {
       std::size_t h1 = std::hash<Format>()(di.format);
       std::size_t h2 = std::hash<std::string>()(di.package_resource_name);
       return h1 ^ h2;
@@ -84,15 +95,15 @@ private:
    * Load and parse the message file referenced by the given datatype, or return it from
    * msg_specs_by_datatype
    */
-  const MessageSpec& load_message_spec(const DefinitionIdentifier& definition_identifier);
+  const MessageSpec & load_message_spec(const DefinitionIdentifier & definition_identifier);
 
   std::unordered_map<DefinitionIdentifier, MessageSpec, DefinitionIdentifierHash>
     msg_specs_by_definition_identifier_;
 };
 
 ROSBAG2_STORAGE_MCAP_PUBLIC
-std::set<std::string> parse_dependencies(Format format, const std::string& text,
-                                         const std::string& package_context);
+std::set<std::string> parse_dependencies(
+  Format format, const std::string & text, const std::string & package_context);
 
 }  // namespace rosbag2_storage_mcap::internal
 

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/visibility_control.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/visibility_control.hpp
@@ -24,26 +24,26 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((dllexport))
-    #define ROSBAG2_STORAGE_MCAP_IMPORT __attribute__((dllimport))
-  #else
-    #define ROSBAG2_STORAGE_MCAP_EXPORT __declspec(dllexport)
-    #define ROSBAG2_STORAGE_MCAP_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef ROSBAG2_STORAGE_MCAP_BUILDING_DLL
-    #define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_EXPORT
-  #else
-    #define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_IMPORT
-  #endif
+#ifdef __GNUC__
+#define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((dllexport))
+#define ROSBAG2_STORAGE_MCAP_IMPORT __attribute__((dllimport))
 #else
-  #define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((visibility("default")))
-  #define ROSBAG2_STORAGE_MCAP_IMPORT
-  #if __GNUC__ >= 4
-    #define ROSBAG2_STORAGE_MCAP_PUBLIC __attribute__((visibility("default")))
-  #else
-    #define ROSBAG2_STORAGE_MCAP_PUBLIC
-  #endif
+#define ROSBAG2_STORAGE_MCAP_EXPORT __declspec(dllexport)
+#define ROSBAG2_STORAGE_MCAP_IMPORT __declspec(dllimport)
+#endif
+#ifdef ROSBAG2_STORAGE_MCAP_BUILDING_DLL
+#define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_EXPORT
+#else
+#define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_IMPORT
+#endif
+#else
+#define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((visibility("default")))
+#define ROSBAG2_STORAGE_MCAP_IMPORT
+#if __GNUC__ >= 4
+#define ROSBAG2_STORAGE_MCAP_PUBLIC __attribute__((visibility("default")))
+#else
+#define ROSBAG2_STORAGE_MCAP_PUBLIC
+#endif
 #endif
 
 #endif  // ROSBAG2_STORAGE_MCAP__VISIBILITY_CONTROL_HPP_

--- a/rosbag2_storage_mcap/include/rosbag2_storage_mcap/visibility_control.hpp
+++ b/rosbag2_storage_mcap/include/rosbag2_storage_mcap/visibility_control.hpp
@@ -24,26 +24,26 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-#ifdef __GNUC__
-#define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((dllexport))
-#define ROSBAG2_STORAGE_MCAP_IMPORT __attribute__((dllimport))
+  #ifdef __GNUC__
+    #define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((dllexport))
+    #define ROSBAG2_STORAGE_MCAP_IMPORT __attribute__((dllimport))
+  #else
+    #define ROSBAG2_STORAGE_MCAP_EXPORT __declspec(dllexport)
+    #define ROSBAG2_STORAGE_MCAP_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSBAG2_STORAGE_MCAP_BUILDING_DLL
+    #define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_EXPORT
+  #else
+    #define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_IMPORT
+  #endif
 #else
-#define ROSBAG2_STORAGE_MCAP_EXPORT __declspec(dllexport)
-#define ROSBAG2_STORAGE_MCAP_IMPORT __declspec(dllimport)
-#endif
-#ifdef ROSBAG2_STORAGE_MCAP_BUILDING_DLL
-#define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_EXPORT
-#else
-#define ROSBAG2_STORAGE_MCAP_PUBLIC ROSBAG2_STORAGE_MCAP_IMPORT
-#endif
-#else
-#define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((visibility("default")))
-#define ROSBAG2_STORAGE_MCAP_IMPORT
-#if __GNUC__ >= 4
-#define ROSBAG2_STORAGE_MCAP_PUBLIC __attribute__((visibility("default")))
-#else
-#define ROSBAG2_STORAGE_MCAP_PUBLIC
-#endif
+  #define ROSBAG2_STORAGE_MCAP_EXPORT __attribute__((visibility("default")))
+  #define ROSBAG2_STORAGE_MCAP_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSBAG2_STORAGE_MCAP_PUBLIC __attribute__((visibility("default")))
+  #else
+    #define ROSBAG2_STORAGE_MCAP_PUBLIC
+  #endif
 #endif
 
 #endif  // ROSBAG2_STORAGE_MCAP__VISIBILITY_CONTROL_HPP_

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -52,10 +52,12 @@
 
 #define DECLARE_YAML_VALUE_MAP(KEY_TYPE, VALUE_TYPE, ...)                   \
   template <>                                                               \
-  struct convert<KEY_TYPE> {                                                \
-    static Node encode(const KEY_TYPE& e) {                                 \
+  struct convert<KEY_TYPE>                                                  \
+  {                                                                         \
+    static Node encode(const KEY_TYPE & e)                                  \
+    {                                                                       \
       static const std::pair<KEY_TYPE, VALUE_TYPE> mapping[] = __VA_ARGS__; \
-      for (const auto& m : mapping) {                                       \
+      for (const auto & m : mapping) {                                      \
         if (m.first == e) {                                                 \
           return Node(m.second);                                            \
         }                                                                   \
@@ -63,10 +65,11 @@
       return Node("");                                                      \
     }                                                                       \
                                                                             \
-    static bool decode(const Node& node, KEY_TYPE& e) {                     \
+    static bool decode(const Node & node, KEY_TYPE & e)                     \
+    {                                                                       \
       static const std::pair<KEY_TYPE, VALUE_TYPE> mapping[] = __VA_ARGS__; \
       const auto val = node.as<VALUE_TYPE>();                               \
-      for (const auto& m : mapping) {                                       \
+      for (const auto & m : mapping) {                                      \
         if (m.second == val) {                                              \
           e = m.first;                                                      \
           return true;                                                      \
@@ -76,43 +79,53 @@
     }                                                                       \
   }
 
-namespace {
+namespace
+{
 
 // Simple wrapper with default constructor for use by YAML
-struct McapWriterOptions : mcap::McapWriterOptions {
+struct McapWriterOptions : mcap::McapWriterOptions
+{
   McapWriterOptions()
-      : mcap::McapWriterOptions("ros2") {}
+      : mcap::McapWriterOptions("ros2")
+  {
+  }
 };
 
 }  // namespace
 
-namespace YAML {
+namespace YAML
+{
 
 #ifndef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
 template <typename T>
-void optional_assign(const Node& node, std::string field, T& assign_to) {
+void optional_assign(const Node & node, std::string field, T & assign_to)
+{
   if (node[field]) {
     assign_to = node[field].as<T>();
   }
 }
 #endif
 
-DECLARE_YAML_VALUE_MAP(mcap::Compression, std::string,
-                       {{mcap::Compression::None, "None"},
-                        {mcap::Compression::Lz4, "Lz4"},
-                        {mcap::Compression::Zstd, "Zstd"}});
+DECLARE_YAML_VALUE_MAP(
+  mcap::Compression, std::string,
+  {{mcap::Compression::None, "None"},
+   {mcap::Compression::Lz4, "Lz4"},
+   {mcap::Compression::Zstd, "Zstd"}});
 
-DECLARE_YAML_VALUE_MAP(mcap::CompressionLevel, std::string,
-                       {{mcap::CompressionLevel::Fastest, "Fastest"},
-                        {mcap::CompressionLevel::Fast, "Fast"},
-                        {mcap::CompressionLevel::Default, "Default"},
-                        {mcap::CompressionLevel::Slow, "Slow"},
-                        {mcap::CompressionLevel::Slowest, "Slowest"}});
+DECLARE_YAML_VALUE_MAP(
+  mcap::CompressionLevel, std::string,
+  {{mcap::CompressionLevel::Fastest, "Fastest"},
+   {mcap::CompressionLevel::Fast, "Fast"},
+   {mcap::CompressionLevel::Default, "Default"},
+   {mcap::CompressionLevel::Slow, "Slow"},
+   {mcap::CompressionLevel::Slowest, "Slowest"}});
 
 template <>
-struct convert<McapWriterOptions> {
+struct convert<McapWriterOptions>
+{
   // NOTE: when updating this struct, also update documentation in README.md
-  static bool decode(const Node& node, McapWriterOptions& o) {
+  static bool decode(const Node & node, McapWriterOptions & o)
+  {
     optional_assign<bool>(node, "noChunkCRC", o.noChunkCRC);
     optional_assign<bool>(node, "noAttachmentCRC", o.noAttachmentCRC);
     optional_assign<bool>(node, "enableDataCRC", o.enableDataCRC);
@@ -138,36 +151,41 @@ struct convert<McapWriterOptions> {
 
 }  // namespace YAML
 
-namespace rosbag2_storage_plugins {
+namespace rosbag2_storage_plugins
+{
 
 using mcap::ByteOffset;
 using time_point = std::chrono::time_point<std::chrono::high_resolution_clock>;
 static const char FILE_EXTENSION[] = ".mcap";
 static const char LOG_NAME[] = "rosbag2_storage_mcap";
 
-static void OnProblem(const mcap::Status& status) {
+static void OnProblem(const mcap::Status & status)
+{
   RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "%s", status.message.c_str());
 }
 
 /**
  * A storage implementation for the MCAP file format.
  */
-class MCAPStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterface {
+class MCAPStorage : public rosbag2_storage::storage_interfaces::ReadWriteInterface
+{
 public:
   MCAPStorage();
   ~MCAPStorage() override;
 
   /** BaseIOInterface **/
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-  void open(const rosbag2_storage::StorageOptions& storage_options,
-            rosbag2_storage::storage_interfaces::IOFlag io_flag =
-              rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
-  void open(const std::string& uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
-                                      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE);
+  void open(
+    const rosbag2_storage::StorageOptions & storage_options,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag =
+      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+  void open(
+    const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
+                               rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE);
 #else
-  void open(const std::string& uri,
-            rosbag2_storage::storage_interfaces::IOFlag io_flag =
-              rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+  void open(
+    const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
+                               rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
 #endif
 
   /** BaseInfoInterface **/
@@ -178,19 +196,19 @@ public:
 
   /** BaseReadInterface **/
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_SET_READ_ORDER
-  void set_read_order(const rosbag2_storage::ReadOrder&) override;
+  void set_read_order(const rosbag2_storage::ReadOrder &) override;
 #endif
   bool has_next() override;
   std::shared_ptr<rosbag2_storage::SerializedBagMessage> read_next() override;
   std::vector<rosbag2_storage::TopicMetadata> get_all_topics_and_types() override;
 
   /** ReadOnlyInterface **/
-  void set_filter(const rosbag2_storage::StorageFilter& storage_filter) override;
+  void set_filter(const rosbag2_storage::StorageFilter & storage_filter) override;
   void reset_filter() override;
 #ifdef ROSBAG2_STORAGE_MCAP_OVERRIDE_SEEK_METHOD
-  void seek(const rcutils_time_point_value_t& time_stamp) override;
+  void seek(const rcutils_time_point_value_t & time_stamp) override;
 #else
-  void seek(const rcutils_time_point_value_t& timestamp);
+  void seek(const rcutils_time_point_value_t & timestamp);
 #endif
 
   /** ReadWriteInterface **/
@@ -199,14 +217,14 @@ public:
   /** BaseWriteInterface **/
   void write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) override;
   void write(
-    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>& msg) override;
-  void create_topic(const rosbag2_storage::TopicMetadata& topic) override;
-  void remove_topic(const rosbag2_storage::TopicMetadata& topic) override;
+    const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msg) override;
+  void create_topic(const rosbag2_storage::TopicMetadata & topic) override;
+  void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
 private:
-  void open_impl(const std::string& uri, const std::string& preset_profile,
-                 rosbag2_storage::storage_interfaces::IOFlag io_flag,
-                 const std::string& storage_config_uri);
+  void open_impl(
+    const std::string & uri, const std::string & preset_profile,
+    rosbag2_storage::storage_interfaces::IOFlag io_flag, const std::string & storage_config_uri);
 
   void reset_iterator(rcutils_time_point_value_t start_time = 0);
   bool read_and_enqueue_message();
@@ -237,12 +255,14 @@ private:
   bool has_read_summary_ = false;
 };
 
-MCAPStorage::MCAPStorage() {
+MCAPStorage::MCAPStorage()
+{
   metadata_.storage_identifier = get_storage_identifier();
   metadata_.message_count = 0;
 }
 
-MCAPStorage::~MCAPStorage() {
+MCAPStorage::~MCAPStorage()
+{
   if (mcap_reader_) {
     mcap_reader_->close();
   }
@@ -256,19 +276,23 @@ MCAPStorage::~MCAPStorage() {
 
 /** BaseIOInterface **/
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-void MCAPStorage::open(const rosbag2_storage::StorageOptions& storage_options,
-                       rosbag2_storage::storage_interfaces::IOFlag io_flag) {
-  open_impl(storage_options.uri, storage_options.storage_preset_profile, io_flag,
-            storage_options.storage_config_uri);
+void MCAPStorage::open(
+  const rosbag2_storage::StorageOptions & storage_options,
+  rosbag2_storage::storage_interfaces::IOFlag io_flag)
+{
+  open_impl(
+    storage_options.uri, storage_options.storage_preset_profile, io_flag,
+    storage_options.storage_config_uri);
 }
 #endif
 
-void MCAPStorage::open(const std::string& uri,
-                       rosbag2_storage::storage_interfaces::IOFlag io_flag) {
+void MCAPStorage::open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag)
+{
   open_impl(uri, "", io_flag, "");
 }
 
-static void SetOptionsForPreset(const std::string& preset_profile, McapWriterOptions& options) {
+static void SetOptionsForPreset(const std::string & preset_profile, McapWriterOptions & options)
+{
   if (preset_profile == "fastwrite") {
     options.noChunking = true;
     options.noSummaryCRC = true;
@@ -288,9 +312,10 @@ static void SetOptionsForPreset(const std::string& preset_profile, McapWriterOpt
   }
 }
 
-void MCAPStorage::open_impl(const std::string& uri, const std::string& preset_profile,
-                            rosbag2_storage::storage_interfaces::IOFlag io_flag,
-                            const std::string& storage_config_uri) {
+void MCAPStorage::open_impl(
+  const std::string & uri, const std::string & preset_profile,
+  rosbag2_storage::storage_interfaces::IOFlag io_flag, const std::string & storage_config_uri)
+{
   switch (io_flag) {
     case rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY: {
       relative_path_ = uri;
@@ -338,7 +363,8 @@ void MCAPStorage::open_impl(const std::string& uri, const std::string& preset_pr
 }
 
 /** BaseInfoInterface **/
-rosbag2_storage::BagMetadata MCAPStorage::get_metadata() {
+rosbag2_storage::BagMetadata MCAPStorage::get_metadata()
+{
   ensure_summary_read();
 
   metadata_.version = 2;
@@ -347,15 +373,15 @@ rosbag2_storage::BagMetadata MCAPStorage::get_metadata() {
   metadata_.relative_file_paths = {get_relative_file_path()};
 
   // Fill out summary metadata from the Statistics record
-  const mcap::Statistics& stats = mcap_reader_->statistics().value();
+  const mcap::Statistics & stats = mcap_reader_->statistics().value();
   metadata_.message_count = stats.messageCount;
   metadata_.duration = std::chrono::nanoseconds(stats.messageEndTime - stats.messageStartTime);
   metadata_.starting_time = time_point(std::chrono::nanoseconds(stats.messageStartTime));
 
   // Build a list of topic information along with per-topic message counts
   metadata_.topics_with_message_count.clear();
-  for (const auto& [channel_id, channel_ptr] : mcap_reader_->channels()) {
-    const mcap::Channel& channel = *channel_ptr;
+  for (const auto & [channel_id, channel_ptr] : mcap_reader_->channels()) {
+    const mcap::Channel & channel = *channel_ptr;
 
     // Look up the Schema for this topic
     const auto schema_ptr = mcap_reader_->schema(channel.schemaId);
@@ -389,28 +415,32 @@ rosbag2_storage::BagMetadata MCAPStorage::get_metadata() {
   return metadata_;
 }
 
-std::string MCAPStorage::get_relative_file_path() const {
+std::string MCAPStorage::get_relative_file_path() const
+{
   return relative_path_;
 }
 
-uint64_t MCAPStorage::get_bagfile_size() const {
+uint64_t MCAPStorage::get_bagfile_size() const
+{
   if (opened_as_ == rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY) {
     return data_source_ ? data_source_->size() : 0;
   } else {
     if (!mcap_writer_) {
       return 0;
     }
-    const auto* data_sink = mcap_writer_->dataSink();
+    const auto * data_sink = mcap_writer_->dataSink();
     return data_sink ? data_sink->size() : 0;
   }
 }
 
-std::string MCAPStorage::get_storage_identifier() const {
+std::string MCAPStorage::get_storage_identifier() const
+{
   return "mcap";
 }
 
 /** BaseReadInterface **/
-bool MCAPStorage::read_and_enqueue_message() {
+bool MCAPStorage::read_and_enqueue_message()
+{
   // The recording has not been opened.
   if (!linear_iterator_) {
     return false;
@@ -420,19 +450,19 @@ bool MCAPStorage::read_and_enqueue_message() {
     return true;
   }
 
-  auto& it = *linear_iterator_;
+  auto & it = *linear_iterator_;
 
   // At the end of the recording
   if (it == linear_view_->end()) {
     return false;
   }
 
-  const auto& messageView = *it;
+  const auto & messageView = *it;
   auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   msg->time_stamp = rcutils_time_point_value_t(messageView.message.logTime);
   msg->topic_name = messageView.channel->topic;
-  msg->serialized_data = rosbag2_storage::make_serialized_message(messageView.message.data,
-                                                                  messageView.message.dataSize);
+  msg->serialized_data = rosbag2_storage::make_serialized_message(
+    messageView.message.data, messageView.message.dataSize);
 
   // enqueue this message to be used
   next_ = msg;
@@ -441,14 +471,15 @@ bool MCAPStorage::read_and_enqueue_message() {
   return true;
 }
 
-void MCAPStorage::reset_iterator(rcutils_time_point_value_t start_time) {
+void MCAPStorage::reset_iterator(rcutils_time_point_value_t start_time)
+{
   ensure_summary_read();
   mcap::ReadMessageOptions options;
   options.startTime = mcap::Timestamp(start_time);
   options.readOrder = read_order_;
   if (!storage_filter_.topics.empty()) {
     options.topicFilter = [this](std::string_view topic) {
-      for (const auto& match_topic : storage_filter_.topics) {
+      for (const auto & match_topic : storage_filter_.topics) {
         if (match_topic == topic) {
           return true;
         }
@@ -471,7 +502,8 @@ void MCAPStorage::reset_iterator(rcutils_time_point_value_t start_time) {
   linear_iterator_ = std::make_unique<mcap::LinearMessageView::Iterator>(linear_view_->begin());
 }
 
-void MCAPStorage::ensure_summary_read() {
+void MCAPStorage::ensure_summary_read()
+{
   if (!has_read_summary_) {
     const auto status = mcap_reader_->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
 
@@ -480,15 +512,15 @@ void MCAPStorage::ensure_summary_read() {
     }
     // check if message indexes are present, if not, read in file order.
     bool message_indexes_found = false;
-    for (const auto& ci : mcap_reader_->chunkIndexes()) {
+    for (const auto & ci : mcap_reader_->chunkIndexes()) {
       if (ci.messageIndexLength > 0) {
         message_indexes_found = true;
         break;
       }
     }
     if (!message_indexes_found) {
-      RCUTILS_LOG_WARN_NAMED(LOG_NAME,
-                             "no message indices found, falling back to reading in file order");
+      RCUTILS_LOG_WARN_NAMED(
+        LOG_NAME, "no message indices found, falling back to reading in file order");
       read_order_ = mcap::ReadMessageOptions::ReadOrder::FileOrder;
     }
     has_read_summary_ = true;
@@ -496,7 +528,8 @@ void MCAPStorage::ensure_summary_read() {
 }
 
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_SET_READ_ORDER
-void MCAPStorage::set_read_order(const rosbag2_storage::ReadOrder& read_order) {
+void MCAPStorage::set_read_order(const rosbag2_storage::ReadOrder & read_order)
+{
   auto next_read_order = read_order_;
   switch (read_order.sort_by) {
     case rosbag2_storage::ReadOrder::ReceivedTimestamp:
@@ -524,7 +557,8 @@ void MCAPStorage::set_read_order(const rosbag2_storage::ReadOrder& read_order) {
 }
 #endif
 
-bool MCAPStorage::has_next() {
+bool MCAPStorage::has_next()
+{
   if (!linear_iterator_) {
     return false;
   }
@@ -536,7 +570,8 @@ bool MCAPStorage::has_next() {
   return read_and_enqueue_message();
 }
 
-std::shared_ptr<rosbag2_storage::SerializedBagMessage> MCAPStorage::read_next() {
+std::shared_ptr<rosbag2_storage::SerializedBagMessage> MCAPStorage::read_next()
+{
   if (!has_next()) {
     throw std::runtime_error{"No next message is available."};
   }
@@ -544,36 +579,42 @@ std::shared_ptr<rosbag2_storage::SerializedBagMessage> MCAPStorage::read_next() 
   return std::move(next_);
 }
 
-std::vector<rosbag2_storage::TopicMetadata> MCAPStorage::get_all_topics_and_types() {
+std::vector<rosbag2_storage::TopicMetadata> MCAPStorage::get_all_topics_and_types()
+{
   auto metadata = get_metadata();
   std::vector<rosbag2_storage::TopicMetadata> out;
-  for (const auto& topic : metadata.topics_with_message_count) {
+  for (const auto & topic : metadata.topics_with_message_count) {
     out.push_back(topic.topic_metadata);
   }
   return out;
 }
 
 /** ReadOnlyInterface **/
-void MCAPStorage::set_filter(const rosbag2_storage::StorageFilter& storage_filter) {
+void MCAPStorage::set_filter(const rosbag2_storage::StorageFilter & storage_filter)
+{
   storage_filter_ = storage_filter;
   reset_iterator();
 }
 
-void MCAPStorage::reset_filter() {
+void MCAPStorage::reset_filter()
+{
   set_filter(rosbag2_storage::StorageFilter());
 }
 
-void MCAPStorage::seek(const rcutils_time_point_value_t& time_stamp) {
+void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
+{
   reset_iterator(time_stamp);
 }
 
 /** ReadWriteInterface **/
-uint64_t MCAPStorage::get_minimum_split_file_size() const {
+uint64_t MCAPStorage::get_minimum_split_file_size() const
+{
   return 1024;
 }
 
 /** BaseWriteInterface **/
-void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg) {
+void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
+{
   const auto topic_it = topics_.find(msg->topic_name);
   if (topic_it == topics_.end()) {
     throw std::runtime_error{"Unknown message topic \"" + msg->topic_name + "\""};
@@ -595,12 +636,12 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   mcap_msg.logTime = mcap::Timestamp(msg->time_stamp);
   mcap_msg.publishTime = mcap_msg.logTime;
   mcap_msg.dataSize = msg->serialized_data->buffer_length;
-  mcap_msg.data = reinterpret_cast<const std::byte*>(msg->serialized_data->buffer);
+  mcap_msg.data = reinterpret_cast<const std::byte *>(msg->serialized_data->buffer);
   const auto status = mcap_writer_->write(mcap_msg);
   if (!status.ok()) {
-    throw std::runtime_error{std::string{"Failed to write "} +
-                             std::to_string(msg->serialized_data->buffer_length) +
-                             " byte message to MCAP file: " + status.message};
+    throw std::runtime_error{
+      std::string{"Failed to write "} + std::to_string(msg->serialized_data->buffer_length) +
+      " byte message to MCAP file: " + status.message};
   }
 
   /// Update metadata
@@ -614,13 +655,15 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
 }
 
 void MCAPStorage::write(
-  const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>>& msgs) {
-  for (const auto& msg : msgs) {
+  const std::vector<std::shared_ptr<const rosbag2_storage::SerializedBagMessage>> & msgs)
+{
+  for (const auto & msg : msgs) {
     write(msg);
   }
 }
 
-void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata& topic) {
+void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
+{
   auto topic_info = rosbag2_storage::TopicInformation{topic, 0};
   const auto topic_it = topics_.find(topic.name);
   if (topic_it == topics_.end()) {
@@ -631,7 +674,7 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata& topic) {
   }
 
   // Create Schema for topic if it doesn't exist yet
-  const auto& datatype = topic_info.topic_metadata.type;
+  const auto & datatype = topic_info.topic_metadata.type;
   const auto schema_it = schema_ids_.find(datatype);
   mcap::SchemaId schema_id;
   if (schema_it == schema_ids_.end()) {
@@ -644,11 +687,12 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata& topic) {
       } else {
         schema.encoding = "ros2idl";
       }
-      schema.data.assign(reinterpret_cast<const std::byte*>(full_text.data()),
-                         reinterpret_cast<const std::byte*>(full_text.data() + full_text.size()));
-    } catch (rosbag2_storage_mcap::internal::DefinitionNotFoundError& err) {
-      RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "definition file(s) missing for %s: missing %s",
-                              datatype.c_str(), err.what());
+      schema.data.assign(
+        reinterpret_cast<const std::byte *>(full_text.data()),
+        reinterpret_cast<const std::byte *>(full_text.data() + full_text.size()));
+    } catch (rosbag2_storage_mcap::internal::DefinitionNotFoundError & err) {
+      RCUTILS_LOG_ERROR_NAMED(
+        LOG_NAME, "definition file(s) missing for %s: missing %s", datatype.c_str(), err.what());
       schema.encoding = "";
     }
     mcap_writer_->addSchema(schema);
@@ -665,19 +709,20 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata& topic) {
     channel.topic = topic.name;
     channel.messageEncoding = topic_info.topic_metadata.serialization_format;
     channel.schemaId = schema_id;
-    channel.metadata.emplace("offered_qos_profiles",
-                             topic_info.topic_metadata.offered_qos_profiles);
+    channel.metadata.emplace(
+      "offered_qos_profiles", topic_info.topic_metadata.offered_qos_profiles);
     mcap_writer_->addChannel(channel);
     channel_ids_.emplace(topic.name, channel.id);
   }
 }
 
-void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata& topic) {
+void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
+{
   topics_.erase(topic.name);
 }
 
 }  // namespace rosbag2_storage_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT
-PLUGINLIB_EXPORT_CLASS(rosbag2_storage_plugins::MCAPStorage,
-                       rosbag2_storage::storage_interfaces::ReadWriteInterface)
+PLUGINLIB_EXPORT_CLASS(
+  rosbag2_storage_plugins::MCAPStorage, rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -36,9 +36,10 @@
   #endif
 #endif
 
+#include <mcap/mcap.hpp>
+
 #include <algorithm>
 #include <filesystem>
-#include <mcap/mcap.hpp>
 #include <memory>
 #include <optional>
 #include <string>
@@ -83,7 +84,10 @@ namespace
 // Simple wrapper with default constructor for use by YAML
 struct McapWriterOptions : mcap::McapWriterOptions
 {
-  McapWriterOptions() : mcap::McapWriterOptions("ros2") {}
+  McapWriterOptions()
+      : mcap::McapWriterOptions("ros2")
+  {
+  }
 };
 }  // namespace
 
@@ -99,19 +103,17 @@ void optional_assign(const Node & node, std::string field, T & assign_to)
 }
 #endif
 
-DECLARE_YAML_VALUE_MAP(
-  mcap::Compression, std::string,
-  {{mcap::Compression::None, "None"},
-   {mcap::Compression::Lz4, "Lz4"},
-   {mcap::Compression::Zstd, "Zstd"}});
+DECLARE_YAML_VALUE_MAP(mcap::Compression, std::string,
+                       {{mcap::Compression::None, "None"},
+                        {mcap::Compression::Lz4, "Lz4"},
+                        {mcap::Compression::Zstd, "Zstd"}});
 
-DECLARE_YAML_VALUE_MAP(
-  mcap::CompressionLevel, std::string,
-  {{mcap::CompressionLevel::Fastest, "Fastest"},
-   {mcap::CompressionLevel::Fast, "Fast"},
-   {mcap::CompressionLevel::Default, "Default"},
-   {mcap::CompressionLevel::Slow, "Slow"},
-   {mcap::CompressionLevel::Slowest, "Slowest"}});
+DECLARE_YAML_VALUE_MAP(mcap::CompressionLevel, std::string,
+                       {{mcap::CompressionLevel::Fastest, "Fastest"},
+                        {mcap::CompressionLevel::Fast, "Fast"},
+                        {mcap::CompressionLevel::Default, "Default"},
+                        {mcap::CompressionLevel::Slow, "Slow"},
+                        {mcap::CompressionLevel::Slowest, "Slowest"}});
 
 template <>
 struct convert<McapWriterOptions>
@@ -166,17 +168,15 @@ public:
 
   /** BaseIOInterface **/
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-  void open(
-    const rosbag2_storage::StorageOptions & storage_options,
-    rosbag2_storage::storage_interfaces::IOFlag io_flag =
-      rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
-  void open(
-    const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
-                               rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE);
+  void open(const rosbag2_storage::StorageOptions & storage_options,
+            rosbag2_storage::storage_interfaces::IOFlag io_flag =
+              rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+  void open(const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
+                                       rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE);
 #else
-  void open(
-    const std::string & uri, rosbag2_storage::storage_interfaces::IOFlag io_flag =
-                               rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
+  void open(const std::string & uri,
+            rosbag2_storage::storage_interfaces::IOFlag io_flag =
+              rosbag2_storage::storage_interfaces::IOFlag::READ_WRITE) override;
 #endif
 
   /** BaseInfoInterface **/
@@ -213,9 +213,9 @@ public:
   void remove_topic(const rosbag2_storage::TopicMetadata & topic) override;
 
 private:
-  void open_impl(
-    const std::string & uri, const std::string & preset_profile,
-    rosbag2_storage::storage_interfaces::IOFlag io_flag, const std::string & storage_config_uri);
+  void open_impl(const std::string & uri, const std::string & preset_profile,
+                 rosbag2_storage::storage_interfaces::IOFlag io_flag,
+                 const std::string & storage_config_uri);
 
   void reset_iterator(rcutils_time_point_value_t start_time = 0);
   bool read_and_enqueue_message();
@@ -267,13 +267,11 @@ MCAPStorage::~MCAPStorage()
 
 /** BaseIOInterface **/
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-void MCAPStorage::open(
-  const rosbag2_storage::StorageOptions & storage_options,
-  rosbag2_storage::storage_interfaces::IOFlag io_flag)
+void MCAPStorage::open(const rosbag2_storage::StorageOptions & storage_options,
+                       rosbag2_storage::storage_interfaces::IOFlag io_flag)
 {
-  open_impl(
-    storage_options.uri, storage_options.storage_preset_profile, io_flag,
-    storage_options.storage_config_uri);
+  open_impl(storage_options.uri, storage_options.storage_preset_profile, io_flag,
+            storage_options.storage_config_uri);
 }
 #endif
 
@@ -303,9 +301,9 @@ static void SetOptionsForPreset(const std::string & preset_profile, McapWriterOp
   }
 }
 
-void MCAPStorage::open_impl(
-  const std::string & uri, const std::string & preset_profile,
-  rosbag2_storage::storage_interfaces::IOFlag io_flag, const std::string & storage_config_uri)
+void MCAPStorage::open_impl(const std::string & uri, const std::string & preset_profile,
+                            rosbag2_storage::storage_interfaces::IOFlag io_flag,
+                            const std::string & storage_config_uri)
 {
   switch (io_flag) {
     case rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY: {
@@ -406,7 +404,10 @@ rosbag2_storage::BagMetadata MCAPStorage::get_metadata()
   return metadata_;
 }
 
-std::string MCAPStorage::get_relative_file_path() const { return relative_path_; }
+std::string MCAPStorage::get_relative_file_path() const
+{
+  return relative_path_;
+}
 
 uint64_t MCAPStorage::get_bagfile_size() const
 {
@@ -421,7 +422,10 @@ uint64_t MCAPStorage::get_bagfile_size() const
   }
 }
 
-std::string MCAPStorage::get_storage_identifier() const { return "mcap"; }
+std::string MCAPStorage::get_storage_identifier() const
+{
+  return "mcap";
+}
 
 /** BaseReadInterface **/
 bool MCAPStorage::read_and_enqueue_message()
@@ -446,8 +450,8 @@ bool MCAPStorage::read_and_enqueue_message()
   auto msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
   msg->time_stamp = rcutils_time_point_value_t(messageView.message.logTime);
   msg->topic_name = messageView.channel->topic;
-  msg->serialized_data = rosbag2_storage::make_serialized_message(
-    messageView.message.data, messageView.message.dataSize);
+  msg->serialized_data = rosbag2_storage::make_serialized_message(messageView.message.data,
+                                                                  messageView.message.dataSize);
 
   // enqueue this message to be used
   next_ = msg;
@@ -504,8 +508,8 @@ void MCAPStorage::ensure_summary_read()
       }
     }
     if (!message_indexes_found) {
-      RCUTILS_LOG_WARN_NAMED(
-        LOG_NAME, "no message indices found, falling back to reading in file order");
+      RCUTILS_LOG_WARN_NAMED(LOG_NAME,
+                             "no message indices found, falling back to reading in file order");
       read_order_ = mcap::ReadMessageOptions::ReadOrder::FileOrder;
     }
     has_read_summary_ = true;
@@ -581,7 +585,10 @@ void MCAPStorage::set_filter(const rosbag2_storage::StorageFilter & storage_filt
   reset_iterator();
 }
 
-void MCAPStorage::reset_filter() { set_filter(rosbag2_storage::StorageFilter()); }
+void MCAPStorage::reset_filter()
+{
+  set_filter(rosbag2_storage::StorageFilter());
+}
 
 void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
 {
@@ -589,7 +596,10 @@ void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
 }
 
 /** ReadWriteInterface **/
-uint64_t MCAPStorage::get_minimum_split_file_size() const { return 1024; }
+uint64_t MCAPStorage::get_minimum_split_file_size() const
+{
+  return 1024;
+}
 
 /** BaseWriteInterface **/
 void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)
@@ -618,9 +628,9 @@ void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMess
   mcap_msg.data = reinterpret_cast<const std::byte *>(msg->serialized_data->buffer);
   const auto status = mcap_writer_->write(mcap_msg);
   if (!status.ok()) {
-    throw std::runtime_error{
-      std::string{"Failed to write "} + std::to_string(msg->serialized_data->buffer_length) +
-      " byte message to MCAP file: " + status.message};
+    throw std::runtime_error{std::string{"Failed to write "} +
+                             std::to_string(msg->serialized_data->buffer_length) +
+                             " byte message to MCAP file: " + status.message};
   }
 
   /// Update metadata
@@ -666,12 +676,11 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
       } else {
         schema.encoding = "ros2idl";
       }
-      schema.data.assign(
-        reinterpret_cast<const std::byte *>(full_text.data()),
-        reinterpret_cast<const std::byte *>(full_text.data() + full_text.size()));
+      schema.data.assign(reinterpret_cast<const std::byte *>(full_text.data()),
+                         reinterpret_cast<const std::byte *>(full_text.data() + full_text.size()));
     } catch (rosbag2_storage_mcap::internal::DefinitionNotFoundError & err) {
-      RCUTILS_LOG_ERROR_NAMED(
-        LOG_NAME, "definition file(s) missing for %s: missing %s", datatype.c_str(), err.what());
+      RCUTILS_LOG_ERROR_NAMED(LOG_NAME, "definition file(s) missing for %s: missing %s",
+                              datatype.c_str(), err.what());
       schema.encoding = "";
     }
     mcap_writer_->addSchema(schema);
@@ -688,8 +697,8 @@ void MCAPStorage::create_topic(const rosbag2_storage::TopicMetadata & topic)
     channel.topic = topic.name;
     channel.messageEncoding = topic_info.topic_metadata.serialization_format;
     channel.schemaId = schema_id;
-    channel.metadata.emplace(
-      "offered_qos_profiles", topic_info.topic_metadata.offered_qos_profiles);
+    channel.metadata.emplace("offered_qos_profiles",
+                             topic_info.topic_metadata.offered_qos_profiles);
     mcap_writer_->addChannel(channel);
     channel_ids_.emplace(topic.name, channel.id);
   }
@@ -702,5 +711,5 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
 }  // namespace rosbag2_storage_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT
-PLUGINLIB_EXPORT_CLASS(
-  rosbag2_storage_plugins::MCAPStorage, rosbag2_storage::storage_interfaces::ReadWriteInterface)
+PLUGINLIB_EXPORT_CLASS(rosbag2_storage_plugins::MCAPStorage,
+                       rosbag2_storage::storage_interfaces::ReadWriteInterface)

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -19,27 +19,26 @@
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
-  #include "rosbag2_storage/yaml.hpp"
+#include "rosbag2_storage/yaml.hpp"
 #else
-  // COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
-  #ifdef _WIN32
-    // This is necessary because of a bug in yaml-cpp's cmake
-    #define YAML_CPP_DLL
-    // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-    #pragma warning(push)
-    #pragma warning(disable : 4251)
-    #pragma warning(disable : 4275)
-  #endif
-  #include "yaml-cpp/yaml.h"
-  #ifdef _WIN32
-    #pragma warning(pop)
-  #endif
+// COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
+#ifdef _WIN32
+// This is necessary because of a bug in yaml-cpp's cmake
+#define YAML_CPP_DLL
+// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#pragma warning(disable : 4275)
 #endif
-
-#include <mcap/mcap.hpp>
+#include "yaml-cpp/yaml.h"
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+#endif
 
 #include <algorithm>
 #include <filesystem>
+#include <mcap/mcap.hpp>
 #include <memory>
 #include <optional>
 #include <string>
@@ -47,7 +46,7 @@
 #include <utility>
 #include <vector>
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_FILTER_TOPIC_REGEX
-  #include <regex>
+#include <regex>
 #endif
 
 #define DECLARE_YAML_VALUE_MAP(KEY_TYPE, VALUE_TYPE, ...)                   \
@@ -85,10 +84,7 @@ namespace
 // Simple wrapper with default constructor for use by YAML
 struct McapWriterOptions : mcap::McapWriterOptions
 {
-  McapWriterOptions()
-      : mcap::McapWriterOptions("ros2")
-  {
-  }
+  McapWriterOptions() : mcap::McapWriterOptions("ros2") {}
 };
 
 }  // namespace
@@ -415,10 +411,7 @@ rosbag2_storage::BagMetadata MCAPStorage::get_metadata()
   return metadata_;
 }
 
-std::string MCAPStorage::get_relative_file_path() const
-{
-  return relative_path_;
-}
+std::string MCAPStorage::get_relative_file_path() const { return relative_path_; }
 
 uint64_t MCAPStorage::get_bagfile_size() const
 {
@@ -433,10 +426,7 @@ uint64_t MCAPStorage::get_bagfile_size() const
   }
 }
 
-std::string MCAPStorage::get_storage_identifier() const
-{
-  return "mcap";
-}
+std::string MCAPStorage::get_storage_identifier() const { return "mcap"; }
 
 /** BaseReadInterface **/
 bool MCAPStorage::read_and_enqueue_message()
@@ -596,10 +586,7 @@ void MCAPStorage::set_filter(const rosbag2_storage::StorageFilter & storage_filt
   reset_iterator();
 }
 
-void MCAPStorage::reset_filter()
-{
-  set_filter(rosbag2_storage::StorageFilter());
-}
+void MCAPStorage::reset_filter() { set_filter(rosbag2_storage::StorageFilter()); }
 
 void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
 {
@@ -607,10 +594,7 @@ void MCAPStorage::seek(const rcutils_time_point_value_t & time_stamp)
 }
 
 /** ReadWriteInterface **/
-uint64_t MCAPStorage::get_minimum_split_file_size() const
-{
-  return 1024;
-}
+uint64_t MCAPStorage::get_minimum_split_file_size() const { return 1024; }
 
 /** BaseWriteInterface **/
 void MCAPStorage::write(std::shared_ptr<const rosbag2_storage::SerializedBagMessage> msg)

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -80,18 +80,15 @@
 
 namespace
 {
-
 // Simple wrapper with default constructor for use by YAML
 struct McapWriterOptions : mcap::McapWriterOptions
 {
   McapWriterOptions() : mcap::McapWriterOptions("ros2") {}
 };
-
 }  // namespace
 
 namespace YAML
 {
-
 #ifndef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
 template <typename T>
 void optional_assign(const Node & node, std::string field, T & assign_to)
@@ -144,12 +141,10 @@ struct convert<McapWriterOptions>
     return true;
   }
 };
-
 }  // namespace YAML
 
 namespace rosbag2_storage_plugins
 {
-
 using mcap::ByteOffset;
 using time_point = std::chrono::time_point<std::chrono::high_resolution_clock>;
 static const char FILE_EXTENSION[] = ".mcap";
@@ -704,7 +699,6 @@ void MCAPStorage::remove_topic(const rosbag2_storage::TopicMetadata & topic)
 {
   topics_.erase(topic.name);
 }
-
 }  // namespace rosbag2_storage_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT

--- a/rosbag2_storage_mcap/src/mcap_storage.cpp
+++ b/rosbag2_storage_mcap/src/mcap_storage.cpp
@@ -19,21 +19,21 @@
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_YAML_HPP
-#include "rosbag2_storage/yaml.hpp"
+  #include "rosbag2_storage/yaml.hpp"
 #else
-// COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
-#ifdef _WIN32
-// This is necessary because of a bug in yaml-cpp's cmake
-#define YAML_CPP_DLL
-// This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#pragma warning(disable : 4275)
-#endif
-#include "yaml-cpp/yaml.h"
-#ifdef _WIN32
-#pragma warning(pop)
-#endif
+  // COMPATIBILITY(foxy, galactic) - this block is available in rosbag2_storage/yaml.hpp in H
+  #ifdef _WIN32
+    // This is necessary because of a bug in yaml-cpp's cmake
+    #define YAML_CPP_DLL
+    // This is necessary because yaml-cpp does not always use dllimport/dllexport consistently
+    #pragma warning(push)
+    #pragma warning(disable : 4251)
+    #pragma warning(disable : 4275)
+  #endif
+  #include "yaml-cpp/yaml.h"
+  #ifdef _WIN32
+    #pragma warning(pop)
+  #endif
 #endif
 
 #include <algorithm>
@@ -46,7 +46,7 @@
 #include <utility>
 #include <vector>
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_FILTER_TOPIC_REGEX
-#include <regex>
+  #include <regex>
 #endif
 
 #define DECLARE_YAML_VALUE_MAP(KEY_TYPE, VALUE_TYPE, ...)                   \

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -14,11 +14,11 @@
 
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <ament_index_cpp/get_resource.hpp>
 #include <ament_index_cpp/get_resources.hpp>
-#include <rcutils/logging_macros.h>
-
 #include <fstream>
 #include <functional>
 #include <optional>
@@ -121,9 +121,9 @@ static std::string delimiter(const DefinitionIdentifier & definition_identifier)
 }
 
 MessageSpec::MessageSpec(Format format, std::string text, const std::string & package_context)
-    : dependencies(parse_dependencies(format, text, package_context))
-    , text(std::move(text))
-    , format(format)
+: dependencies(parse_dependencies(format, text, package_context)),
+  text(std::move(text)),
+  format(format)
 {
 }
 

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -28,7 +28,8 @@
 #include <unordered_set>
 #include <utility>
 
-namespace rosbag2_storage_mcap::internal {
+namespace rosbag2_storage_mcap::internal
+{
 
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
 static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/)?([a-zA-Z0-9_]+)$)"};
@@ -44,8 +45,9 @@ static const std::unordered_set<std::string> PRIMITIVE_TYPES{
   "bool",  "byte",   "char",  "float32", "float64", "int8",   "uint8",
   "int16", "uint16", "int32", "uint32",  "int64",   "uint64", "string"};
 
-static std::set<std::string> parse_msg_dependencies(const std::string& text,
-                                                    const std::string& package_context) {
+static std::set<std::string> parse_msg_dependencies(
+  const std::string & text, const std::string & package_context)
+{
   std::set<std::string> dependencies;
 
   for (std::sregex_iterator iter(text.begin(), text.end(), MSG_FIELD_TYPE_REGEX);
@@ -63,7 +65,8 @@ static std::set<std::string> parse_msg_dependencies(const std::string& text,
   return dependencies;
 }
 
-static std::set<std::string> parse_idl_dependencies(const std::string& text) {
+static std::set<std::string> parse_idl_dependencies(const std::string & text)
+{
   std::set<std::string> dependencies;
 
   for (std::sregex_iterator iter(text.begin(), text.end(), IDL_FIELD_TYPE_REGEX);
@@ -73,8 +76,9 @@ static std::set<std::string> parse_idl_dependencies(const std::string& text) {
   return dependencies;
 }
 
-std::set<std::string> parse_dependencies(Format format, const std::string& text,
-                                         const std::string& package_context) {
+std::set<std::string> parse_dependencies(
+  Format format, const std::string & text, const std::string & package_context)
+{
   switch (format) {
     case Format::MSG:
       return parse_msg_dependencies(text, package_context);
@@ -85,7 +89,8 @@ std::set<std::string> parse_dependencies(Format format, const std::string& text,
   }
 }
 
-static const char* extension_for_format(Format format) {
+static const char * extension_for_format(Format format)
+{
   switch (format) {
     case Format::MSG:
       return ".msg";
@@ -96,7 +101,8 @@ static const char* extension_for_format(Format format) {
   }
 }
 
-static std::string delimiter(const DefinitionIdentifier& definition_identifier) {
+static std::string delimiter(const DefinitionIdentifier & definition_identifier)
+{
   std::string result =
     "================================================================================\n";
   switch (definition_identifier.format) {
@@ -114,36 +120,40 @@ static std::string delimiter(const DefinitionIdentifier& definition_identifier) 
   return result;
 }
 
-MessageSpec::MessageSpec(Format format, std::string text, const std::string& package_context)
+MessageSpec::MessageSpec(Format format, std::string text, const std::string & package_context)
     : dependencies(parse_dependencies(format, text, package_context))
     , text(std::move(text))
-    , format(format) {}
+    , format(format)
+{
+}
 
-const MessageSpec& MessageDefinitionCache::load_message_spec(
-  const DefinitionIdentifier& definition_identifier) {
+const MessageSpec & MessageDefinitionCache::load_message_spec(
+  const DefinitionIdentifier & definition_identifier)
+{
   if (auto it = msg_specs_by_definition_identifier_.find(definition_identifier);
       it != msg_specs_by_definition_identifier_.end()) {
     return it->second;
   }
   std::smatch match;
-  if (!std::regex_match(definition_identifier.package_resource_name, match,
-                        PACKAGE_TYPENAME_REGEX)) {
-    throw std::invalid_argument("Invalid package resource name: " +
-                                definition_identifier.package_resource_name);
+  if (!std::regex_match(
+        definition_identifier.package_resource_name, match, PACKAGE_TYPENAME_REGEX)) {
+    throw std::invalid_argument(
+      "Invalid package resource name: " + definition_identifier.package_resource_name);
   }
   std::string package = match[1];
   std::string share_dir = ament_index_cpp::get_package_share_directory(package);
-  std::ifstream file{share_dir + "/msg/" + match[2].str() +
-                     extension_for_format(definition_identifier.format)};
+  std::ifstream file{
+    share_dir + "/msg/" + match[2].str() + extension_for_format(definition_identifier.format)};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);
   }
 
   std::string contents{std::istreambuf_iterator(file), {}};
-  const MessageSpec& spec =
+  const MessageSpec & spec =
     msg_specs_by_definition_identifier_
-      .emplace(definition_identifier,
-               MessageSpec(definition_identifier.format, std::move(contents), package))
+      .emplace(
+        definition_identifier,
+        MessageSpec(definition_identifier.format, std::move(contents), package))
       .first->second;
 
   // "References and pointers to data stored in the container are only invalidated by erasing that
@@ -152,14 +162,15 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
 }
 
 std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
-  const std::string& root_package_resource_name) {
+  const std::string & root_package_resource_name)
+{
   std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
 
-  std::function<std::string(const DefinitionIdentifier&)> append_recursive =
-    [&](const DefinitionIdentifier& definition_identifier) {
-      const MessageSpec& spec = load_message_spec(definition_identifier);
+  std::function<std::string(const DefinitionIdentifier &)> append_recursive =
+    [&](const DefinitionIdentifier & definition_identifier) {
+      const MessageSpec & spec = load_message_spec(definition_identifier);
       std::string result = spec.text;
-      for (const auto& dep_name : spec.dependencies) {
+      for (const auto & dep_name : spec.dependencies) {
         DefinitionIdentifier dep{definition_identifier.format, dep_name};
         bool inserted = seen_deps.insert(dep).second;
         if (inserted) {
@@ -175,10 +186,10 @@ std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
   Format format = Format::MSG;
   try {
     result = append_recursive(DefinitionIdentifier{format, root_package_resource_name});
-  } catch (const DefinitionNotFoundError& err) {
+  } catch (const DefinitionNotFoundError & err) {
     // log that we've fallen back
-    RCUTILS_LOG_WARN_NAMED("rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL",
-                           err.what());
+    RCUTILS_LOG_WARN_NAMED(
+      "rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL", err.what());
     format = Format::IDL;
     DefinitionIdentifier root_definition_identifier{format, root_package_resource_name};
     result = delimiter(root_definition_identifier) + append_recursive(root_definition_identifier);

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -14,11 +14,11 @@
 
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
-#include <rcutils/logging_macros.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <ament_index_cpp/get_resource.hpp>
 #include <ament_index_cpp/get_resources.hpp>
+#include <rcutils/logging_macros.h>
+
 #include <fstream>
 #include <functional>
 #include <optional>
@@ -44,8 +44,8 @@ static const std::unordered_set<std::string> PRIMITIVE_TYPES{
   "bool",  "byte",   "char",  "float32", "float64", "int8",   "uint8",
   "int16", "uint16", "int32", "uint32",  "int64",   "uint64", "string"};
 
-static std::set<std::string> parse_msg_dependencies(
-  const std::string & text, const std::string & package_context)
+static std::set<std::string> parse_msg_dependencies(const std::string & text,
+                                                    const std::string & package_context)
 {
   std::set<std::string> dependencies;
 
@@ -75,8 +75,8 @@ static std::set<std::string> parse_idl_dependencies(const std::string & text)
   return dependencies;
 }
 
-std::set<std::string> parse_dependencies(
-  Format format, const std::string & text, const std::string & package_context)
+std::set<std::string> parse_dependencies(Format format, const std::string & text,
+                                         const std::string & package_context)
 {
   switch (format) {
     case Format::MSG:
@@ -120,9 +120,9 @@ static std::string delimiter(const DefinitionIdentifier & definition_identifier)
 }
 
 MessageSpec::MessageSpec(Format format, std::string text, const std::string & package_context)
-: dependencies(parse_dependencies(format, text, package_context)),
-  text(std::move(text)),
-  format(format)
+    : dependencies(parse_dependencies(format, text, package_context))
+    , text(std::move(text))
+    , format(format)
 {
 }
 
@@ -134,15 +134,15 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
     return it->second;
   }
   std::smatch match;
-  if (!std::regex_match(
-        definition_identifier.package_resource_name, match, PACKAGE_TYPENAME_REGEX)) {
-    throw std::invalid_argument(
-      "Invalid package resource name: " + definition_identifier.package_resource_name);
+  if (!std::regex_match(definition_identifier.package_resource_name, match,
+                        PACKAGE_TYPENAME_REGEX)) {
+    throw std::invalid_argument("Invalid package resource name: " +
+                                definition_identifier.package_resource_name);
   }
   std::string package = match[1];
   std::string share_dir = ament_index_cpp::get_package_share_directory(package);
-  std::ifstream file{
-    share_dir + "/msg/" + match[2].str() + extension_for_format(definition_identifier.format)};
+  std::ifstream file{share_dir + "/msg/" + match[2].str() +
+                     extension_for_format(definition_identifier.format)};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);
   }
@@ -150,9 +150,8 @@ const MessageSpec & MessageDefinitionCache::load_message_spec(
   std::string contents{std::istreambuf_iterator(file), {}};
   const MessageSpec & spec =
     msg_specs_by_definition_identifier_
-      .emplace(
-        definition_identifier,
-        MessageSpec(definition_identifier.format, std::move(contents), package))
+      .emplace(definition_identifier,
+               MessageSpec(definition_identifier.format, std::move(contents), package))
       .first->second;
 
   // "References and pointers to data stored in the container are only invalidated by erasing that
@@ -187,8 +186,8 @@ std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
     result = append_recursive(DefinitionIdentifier{format, root_package_resource_name});
   } catch (const DefinitionNotFoundError & err) {
     // log that we've fallen back
-    RCUTILS_LOG_WARN_NAMED(
-      "rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL", err.what());
+    RCUTILS_LOG_WARN_NAMED("rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL",
+                           err.what());
     format = Format::IDL;
     DefinitionIdentifier root_definition_identifier{format, root_package_resource_name};
     result = delimiter(root_definition_identifier) + append_recursive(root_definition_identifier);

--- a/rosbag2_storage_mcap/src/message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/src/message_definition_cache.cpp
@@ -30,7 +30,6 @@
 
 namespace rosbag2_storage_mcap::internal
 {
-
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
 static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/)?([a-zA-Z0-9_]+)$)"};
 
@@ -196,5 +195,4 @@ std::pair<Format, std::string> MessageDefinitionCache::get_full_text(
   }
   return std::make_pair(format, result);
 }
-
 }  // namespace rosbag2_storage_mcap::internal

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -20,19 +20,19 @@
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-  #include "rosbag2_storage/storage_options.hpp"
+#include "rosbag2_storage/storage_options.hpp"
 using StorageOptions = rosbag2_storage::StorageOptions;
 #else
-  #include "rosbag2_cpp/storage_options.hpp"
+#include "rosbag2_cpp/storage_options.hpp"
 using StorageOptions = rosbag2_cpp::StorageOptions;
 #endif
-#include "rosbag2_test_common/temporary_directory_fixture.hpp"
-#include "std_msgs/msg/string.hpp"
-
 #include <gmock/gmock.h>
 
 #include <memory>
 #include <string>
+
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
+#include "std_msgs/msg/string.hpp"
 
 using namespace ::testing;  // NOLINT
 using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;
@@ -130,9 +130,9 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
     msg.data = message_data;
 
     rosbag2_cpp::Writer writer{std::make_unique<rosbag2_cpp::writers::SequentialWriter>()};
-  #ifndef ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY
+#ifndef ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY
     rcpputils::fs::create_directories(uri);
-  #endif
+#endif
     writer.open(options, rosbag2_cpp::ConverterOptions{});
     writer.create_topic(topic_metadata);
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -20,10 +20,10 @@
 #include "rosbag2_cpp/writer.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
-#include "rosbag2_storage/storage_options.hpp"
+  #include "rosbag2_storage/storage_options.hpp"
 using StorageOptions = rosbag2_storage::StorageOptions;
 #else
-#include "rosbag2_cpp/storage_options.hpp"
+  #include "rosbag2_cpp/storage_options.hpp"
 using StorageOptions = rosbag2_cpp::StorageOptions;
 #endif
 #include <gmock/gmock.h>
@@ -130,9 +130,9 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
     msg.data = message_data;
 
     rosbag2_cpp::Writer writer{std::make_unique<rosbag2_cpp::writers::SequentialWriter>()};
-#ifndef ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY
+  #ifndef ROSBAG2_STORAGE_MCAP_WRITER_CREATES_DIRECTORY
     rcpputils::fs::create_directories(uri);
-#endif
+  #endif
     writer.open(options, rosbag2_cpp::ConverterOptions{});
     writer.create_topic(topic_metadata);
 

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -37,7 +37,8 @@ using StorageOptions = rosbag2_cpp::StorageOptions;
 using namespace ::testing;  // NOLINT
 using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;
 
-TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
+TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file)
+{
   auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
   auto expected_bag = uri / "bag_0.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
@@ -76,8 +77,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
     // For this example it wouldn't matter, but in case anybody extends this test, it's for safety.
     auto serialized_bag_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     serialized_bag_msg->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
-      const_cast<rcutils_uint8_array_t*>(&serialized_msg->get_rcl_serialized_message()),
-      [](rcutils_uint8_array_t* /* data */) {});
+      const_cast<rcutils_uint8_array_t *>(&serialized_msg->get_rcl_serialized_message()),
+      [](rcutils_uint8_array_t * /* data */) {});
     serialized_bag_msg->time_stamp = time_stamp;
     serialized_bag_msg->topic_name = topic_name;
     writer.write(serialized_bag_msg);
@@ -102,7 +103,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_and_read_basic_mcap_file) {
 
 #ifdef ROSBAG2_STORAGE_MCAP_HAS_STORAGE_OPTIONS
 // This test disabled on Foxy since StorageOptions doesn't have storage_config_uri field on it
-TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml) {
+TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
+{
   auto uri = rcpputils::fs::path(temporary_dir_path_) / "bag";
   auto expected_bag = uri / "bag_0.mcap";
   const int64_t timestamp_nanos = 100;  // arbitrary value
@@ -143,8 +145,8 @@ TEST_F(TemporaryDirectoryFixture, can_write_mcap_with_zstd_configured_from_yaml)
     // For this example it wouldn't matter, but in case anybody extends this test, it's for safety.
     auto serialized_bag_msg = std::make_shared<rosbag2_storage::SerializedBagMessage>();
     serialized_bag_msg->serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
-      const_cast<rcutils_uint8_array_t*>(&serialized_msg->get_rcl_serialized_message()),
-      [](rcutils_uint8_array_t* /* data */) {});
+      const_cast<rcutils_uint8_array_t *>(&serialized_msg->get_rcl_serialized_message()),
+      [](rcutils_uint8_array_t * /* data */) {});
     serialized_bag_msg->time_stamp = time_stamp;
     serialized_bag_msg->topic_name = topic_name;
     writer.write(serialized_bag_msg);

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_mcap_storage.cpp
@@ -26,13 +26,13 @@ using StorageOptions = rosbag2_storage::StorageOptions;
   #include "rosbag2_cpp/storage_options.hpp"
 using StorageOptions = rosbag2_cpp::StorageOptions;
 #endif
+#include "rosbag2_test_common/temporary_directory_fixture.hpp"
+#include "std_msgs/msg/string.hpp"
+
 #include <gmock/gmock.h>
 
 #include <memory>
 #include <string>
-
-#include "rosbag2_test_common/temporary_directory_fixture.hpp"
-#include "std_msgs/msg/string.hpp"
 
 using namespace ::testing;  // NOLINT
 using TemporaryDirectoryFixture = rosbag2_test_common::TemporaryDirectoryFixture;

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
@@ -27,9 +27,9 @@ TEST(test_message_definition_cache, can_find_idl_includes)
 {
   const char sample[] =
     R"r(
-#include "rosbag2_storage_mcap_testdata/msg/BasicIdlA.idl"
-
 #include <rosbag2_storage_mcap_testdata/msg/BasicIdlB.idl>
+
+#include "rosbag2_storage_mcap_testdata/msg/BasicIdlA.idl"
 
 module rosbag2_storage_mcap_testdata {
   module msg {

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-#include "rosbag2_storage_mcap/message_definition_cache.hpp"
-
 #include <set>
 #include <string>
+
+#include "gmock/gmock.h"
+#include "rosbag2_storage_mcap/message_definition_cache.hpp"
 
 using rosbag2_storage_mcap::internal::Format;
 using rosbag2_storage_mcap::internal::MessageDefinitionCache;
@@ -25,7 +25,8 @@ using ::testing::UnorderedElementsAre;
 
 TEST(test_message_definition_cache, can_find_idl_includes)
 {
-  const char sample[] = R"r(
+  const char sample[] =
+    R"r(
 #include "rosbag2_storage_mcap_testdata/msg/BasicIdlA.idl"
 
 #include <rosbag2_storage_mcap_testdata/msg/BasicIdlB.idl>

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
@@ -23,7 +23,8 @@ using rosbag2_storage_mcap::internal::MessageDefinitionCache;
 using rosbag2_storage_mcap::internal::parse_dependencies;
 using ::testing::UnorderedElementsAre;
 
-TEST(test_message_definition_cache, can_find_idl_includes) {
+TEST(test_message_definition_cache, can_find_idl_includes)
+{
   const char sample[] = R"r(
 #include "rosbag2_storage_mcap_testdata/msg/BasicIdlA.idl"
 
@@ -40,16 +41,20 @@ module rosbag2_storage_mcap_testdata {
 
 )r";
   std::set<std::string> dependencies = parse_dependencies(Format::IDL, sample, "");
-  ASSERT_THAT(dependencies, UnorderedElementsAre("rosbag2_storage_mcap_testdata/msg/BasicIdlA",
-                                                 "rosbag2_storage_mcap_testdata/msg/BasicIdlB"));
+  ASSERT_THAT(
+    dependencies, UnorderedElementsAre(
+                    "rosbag2_storage_mcap_testdata/msg/BasicIdlA",
+                    "rosbag2_storage_mcap_testdata/msg/BasicIdlB"));
 }
 
-TEST(test_message_definition_cache, can_find_msg_deps) {
+TEST(test_message_definition_cache, can_find_msg_deps)
+{
   MessageDefinitionCache cache;
   auto [format, content] = cache.get_full_text("rosbag2_storage_mcap_testdata/ComplexMsg");
   ASSERT_EQ(format, Format::MSG);
-  ASSERT_EQ(content,
-            R"r(rosbag2_storage_mcap_testdata/BasicMsg b
+  ASSERT_EQ(
+    content,
+    R"r(rosbag2_storage_mcap_testdata/BasicMsg b
 
 ================================================================================
 MSG: rosbag2_storage_mcap_testdata/BasicMsg
@@ -57,12 +62,14 @@ float32 c
 )r");
 }
 
-TEST(test_message_definition_cache, can_find_idl_deps) {
+TEST(test_message_definition_cache, can_find_idl_deps)
+{
   MessageDefinitionCache cache;
   auto [format, content] = cache.get_full_text("rosbag2_storage_mcap_testdata/msg/ComplexIdl");
   EXPECT_EQ(format, Format::IDL);
-  EXPECT_EQ(content,
-            R"r(================================================================================
+  EXPECT_EQ(
+    content,
+    R"r(================================================================================
 IDL: rosbag2_storage_mcap_testdata/msg/ComplexIdl
 #include "rosbag2_storage_mcap_testdata/msg/BasicIdl.idl"
 
@@ -86,13 +93,15 @@ module rosbag2_storage_mcap_testdata {
 )r");
 }
 
-TEST(test_message_definition_cache, can_resolve_msg_with_idl_deps) {
+TEST(test_message_definition_cache, can_resolve_msg_with_idl_deps)
+{
   MessageDefinitionCache cache;
   auto [format, content] =
     cache.get_full_text("rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl");
   EXPECT_EQ(format, Format::IDL);
-  EXPECT_EQ(content,
-            R"r(================================================================================
+  EXPECT_EQ(
+    content,
+    R"r(================================================================================
 IDL: rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl
 // generated from rosidl_adapter/resource/msg.idl.em
 // with input from rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl.msg

--- a/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
+++ b/rosbag2_storage_mcap/test/rosbag2_storage_mcap/test_message_definition_cache.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <set>
-#include <string>
-
 #include "gmock/gmock.h"
 #include "rosbag2_storage_mcap/message_definition_cache.hpp"
+
+#include <set>
+#include <string>
 
 using rosbag2_storage_mcap::internal::Format;
 using rosbag2_storage_mcap::internal::MessageDefinitionCache;
@@ -27,9 +27,9 @@ TEST(test_message_definition_cache, can_find_idl_includes)
 {
   const char sample[] =
     R"r(
-#include <rosbag2_storage_mcap_testdata/msg/BasicIdlB.idl>
-
 #include "rosbag2_storage_mcap_testdata/msg/BasicIdlA.idl"
+
+#include <rosbag2_storage_mcap_testdata/msg/BasicIdlB.idl>
 
 module rosbag2_storage_mcap_testdata {
   module msg {
@@ -42,10 +42,8 @@ module rosbag2_storage_mcap_testdata {
 
 )r";
   std::set<std::string> dependencies = parse_dependencies(Format::IDL, sample, "");
-  ASSERT_THAT(
-    dependencies, UnorderedElementsAre(
-                    "rosbag2_storage_mcap_testdata/msg/BasicIdlA",
-                    "rosbag2_storage_mcap_testdata/msg/BasicIdlB"));
+  ASSERT_THAT(dependencies, UnorderedElementsAre("rosbag2_storage_mcap_testdata/msg/BasicIdlA",
+                                                 "rosbag2_storage_mcap_testdata/msg/BasicIdlB"));
 }
 
 TEST(test_message_definition_cache, can_find_msg_deps)
@@ -53,9 +51,8 @@ TEST(test_message_definition_cache, can_find_msg_deps)
   MessageDefinitionCache cache;
   auto [format, content] = cache.get_full_text("rosbag2_storage_mcap_testdata/ComplexMsg");
   ASSERT_EQ(format, Format::MSG);
-  ASSERT_EQ(
-    content,
-    R"r(rosbag2_storage_mcap_testdata/BasicMsg b
+  ASSERT_EQ(content,
+            R"r(rosbag2_storage_mcap_testdata/BasicMsg b
 
 ================================================================================
 MSG: rosbag2_storage_mcap_testdata/BasicMsg
@@ -68,9 +65,8 @@ TEST(test_message_definition_cache, can_find_idl_deps)
   MessageDefinitionCache cache;
   auto [format, content] = cache.get_full_text("rosbag2_storage_mcap_testdata/msg/ComplexIdl");
   EXPECT_EQ(format, Format::IDL);
-  EXPECT_EQ(
-    content,
-    R"r(================================================================================
+  EXPECT_EQ(content,
+            R"r(================================================================================
 IDL: rosbag2_storage_mcap_testdata/msg/ComplexIdl
 #include "rosbag2_storage_mcap_testdata/msg/BasicIdl.idl"
 
@@ -100,9 +96,8 @@ TEST(test_message_definition_cache, can_resolve_msg_with_idl_deps)
   auto [format, content] =
     cache.get_full_text("rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl");
   EXPECT_EQ(format, Format::IDL);
-  EXPECT_EQ(
-    content,
-    R"r(================================================================================
+  EXPECT_EQ(content,
+            R"r(================================================================================
 IDL: rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl
 // generated from rosidl_adapter/resource/msg.idl.em
 // with input from rosbag2_storage_mcap_testdata/msg/ComplexMsgDependsOnIdl.msg


### PR DESCRIPTION
Directly uses the ROS 2 clang-format rules from [here](https://github.com/ament/ament_lint/blob/foxy/ament_clang_format/ament_clang_format/configuration/.clang-format). This also brings rosbag2_storage_mcap into compliance with the ROS 2 style guide.

Some notable changes:
(https://google.github.io/styleguide/cppguide.html#Preprocessor_Directives).
* The ROS 2 style guide specifies [pointer alignment](https://docs.ros.org/en/foxy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#pointer-syntax-alignment) differently from our previous rule.
* Line breaks before braces have different rules in the [ROS 2 style guide](https://docs.ros.org/en/foxy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html#open-versus-cuddled-braces).

## Testing
- [x] `ament_clang_format .` returns no errors from repo root
- [x] `ament_cpplint .` returns no errors from repo root
 